### PR TITLE
Expose IEntityManager on SceneContext, resolving abstraction leakage

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/entity/EntityManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/EntityManager.java
@@ -3,17 +3,16 @@ package com.p1_7.abstractengine.entity;
 import java.util.UUID;
 
 import com.badlogic.gdx.utils.Array;
+import com.p1_7.abstractengine.engine.Manager;
 
 /**
- * manages the lifecycle of all entities in the engine. acts as both
- * the read-only repository (IEntityRepository) and the
- * write-side mutator (IEntityMutator).
+ * manages the lifecycle of all entities in the engine. acts as the
+ * unified entity manager (IEntityManager), providing both the
+ * read-only repository and the write-side mutator contracts.
  *
- * this manager extends com.p1_7.abstractengine.engine.Manager
- * directly - it has no per-frame update logic of its own.
+ * this manager has no per-frame update logic of its own.
  */
-public class EntityManager extends com.p1_7.abstractengine.engine.Manager
-        implements IEntityRepository, IEntityMutator {
+public class EntityManager extends Manager implements IEntityManager {
 
     /** the backing store of all live entities */
     private final Array<Entity> entities = new Array<>();
@@ -23,8 +22,7 @@ public class EntityManager extends com.p1_7.abstractengine.engine.Manager
     // ---------------------------------------------------------------
 
     /**
-     * creates an entity via the supplied factory, adds it to the
-     * internal store, and returns it.
+     * creates an entity via the supplied factory, adds it to the internal store, and returns it.
      *
      * @param factory the factory that constructs the concrete entity
      * @return the newly created and registered entity
@@ -54,8 +52,7 @@ public class EntityManager extends com.p1_7.abstractengine.engine.Manager
     }
 
     /**
-     * removes the entity identified by id. performs a linear
-     * scan and removes by index.
+     * removes the entity identified by id. performs a linear scan and removes by index.
      *
      * @param id the UUID of the entity to remove
      */
@@ -74,8 +71,7 @@ public class EntityManager extends com.p1_7.abstractengine.engine.Manager
     // ---------------------------------------------------------------
 
     /**
-     * retrieves a single entity by its unique identifier. performs a
-     * linear scan.
+     * retrieves a single entity by its unique identifier. performs a linear scan.
      *
      * @param id the UUID to look up
      * @return the matching entity, or null if not found
@@ -91,8 +87,7 @@ public class EntityManager extends com.p1_7.abstractengine.engine.Manager
     }
 
     /**
-     * builds and returns a new Array containing the UUIDs of
-     * every entity in the store.
+     * builds and returns a new Array containing the UUIDs of every entity in the store.
      *
      * @return an Array of all entity identifiers
      */
@@ -110,8 +105,7 @@ public class EntityManager extends com.p1_7.abstractengine.engine.Manager
     // ---------------------------------------------------------------
 
     /**
-     * returns a debug string listing the UUIDs of all entities
-     * currently in the store.
+     * returns a debug string listing the UUIDs of all entities currently in the store.
      *
      * @return a human-readable summary of the entity store
      */

--- a/core/src/main/java/com/p1_7/abstractengine/entity/IEntityManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/IEntityManager.java
@@ -1,0 +1,12 @@
+package com.p1_7.abstractengine.entity;
+
+/**
+ * unified contract for the entity store, combining read and write access.
+ *
+ * code that needs both querying and mutation receives this interface.
+ * read-only access is available through IEntityRepository; write-only
+ * access is available through IEntityMutator. implementations may
+ * selectively fulfil either or both contracts based on their needs.
+ */
+public interface IEntityManager extends IEntityRepository, IEntityMutator {
+}

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneContext.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneContext.java
@@ -1,25 +1,26 @@
 package com.p1_7.abstractengine.scene;
 
-import com.p1_7.abstractengine.entity.IEntityRepository;
+import com.p1_7.abstractengine.entity.IEntityManager;
 import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.render.IRenderQueue;
 
 /**
- * read-only snapshot of engine state passed into every Scene
- * callback.
+ * snapshot of engine state passed into every Scene callback.
  *
- * a Scene receives a SceneContext so that it can
- * query entities, submit render items and read input without holding
- * direct references to the underlying managers.
+ * a Scene receives a SceneContext so that it can query and mutate
+ * entities, submit render items, read input, and request scene
+ * transitions — without holding direct references to the underlying
+ * managers.
  */
 public interface SceneContext {
 
     /**
-     * returns the read-only entity repository.
+     * returns the entity manager, providing both read and write access
+     * to the entity store.
      *
-     * @return the IEntityRepository; never null
+     * @return the IEntityManager; never null
      */
-    IEntityRepository entities();
+    IEntityManager entities();
 
     /**
      * returns the render queue for submitting items this frame.

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
@@ -3,7 +3,7 @@ package com.p1_7.abstractengine.scene;
 import com.badlogic.gdx.utils.ObjectMap;
 
 import com.p1_7.abstractengine.engine.UpdatableManager;
-import com.p1_7.abstractengine.entity.IEntityRepository;
+import com.p1_7.abstractengine.entity.IEntityManager;
 import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.render.IRenderQueue;
 
@@ -35,8 +35,8 @@ public class SceneManager extends UpdatableManager {
     /** the context object passed into scene callbacks */
     private SceneContext context;
 
-    /** injected entity repository — used to build the context */
-    private final IEntityRepository entityRepository;
+    /** injected entity manager — used to build the context */
+    private final IEntityManager entityManager;
 
     /** injected render queue — used to build the context */
     private final IRenderQueue renderQueue;
@@ -45,17 +45,17 @@ public class SceneManager extends UpdatableManager {
     private final IInputQuery inputQuery;
 
     /**
-     * constructs a SceneManager with the three dependencies
-     * it needs to assemble a SceneContext.
+     * constructs a SceneManager with the dependencies it needs to
+     * assemble a SceneContext.
      *
-     * @param entityRepository the read-only entity store
-     * @param renderQueue      the single-frame render queue
-     * @param inputQuery       the input query interface
+     * @param entityManager the entity manager providing read and write access
+     * @param renderQueue   the single-frame render queue
+     * @param inputQuery    the input query interface
      */
-    public SceneManager(IEntityRepository entityRepository,
+    public SceneManager(IEntityManager entityManager,
                         IRenderQueue renderQueue,
                         IInputQuery inputQuery) {
-        this.entityRepository = entityRepository;
+        this.entityManager = entityManager;
         this.renderQueue = renderQueue;
         this.inputQuery = inputQuery;
     }
@@ -76,8 +76,8 @@ public class SceneManager extends UpdatableManager {
         // over the injected references
         context = new SceneContext() {
             @Override
-            public IEntityRepository entities() {
-                return entityRepository;
+            public IEntityManager entities() {
+                return entityManager;
             }
 
             @Override

--- a/core/src/main/java/com/p1_7/demo/Main.java
+++ b/core/src/main/java/com/p1_7/demo/Main.java
@@ -56,9 +56,9 @@ public class Main extends ApplicationAdapter {
 
         // 5. create and register all scenes
         MenuScene menuScene = new MenuScene();
-        GameScene gameScene = new GameScene(movementManager, collisionManager, entityManager);
+        GameScene gameScene = new GameScene(movementManager, collisionManager);
         GameOverScene gameOverScene = new GameOverScene();
-        PauseScene pauseScene = new PauseScene(entityManager);
+        PauseScene pauseScene = new PauseScene();
 
         sceneManager.registerScene(menuScene);
         sceneManager.registerScene(gameScene);

--- a/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
@@ -69,22 +69,18 @@ public class GameScene extends Scene {
 
     private final MovementManager movementManager;
     private final CollisionManager collisionManager;
-    private final IEntityMutator entityMutator;
 
     /**
      * constructs a game scene with references to required managers.
      *
      * @param movementManager  the movement manager for bucket registration
      * @param collisionManager the collision manager for entity registration
-     * @param entityMutator    the entity mutator for creation and removal
      */
     public GameScene(MovementManager movementManager,
-                     CollisionManager collisionManager,
-                     IEntityMutator entityMutator) {
+                     CollisionManager collisionManager) {
         this.name = "game";
         this.movementManager = movementManager;
         this.collisionManager = collisionManager;
-        this.entityMutator = entityMutator;
     }
 
     // ==================== lifecycle hooks ====================
@@ -108,17 +104,17 @@ public class GameScene extends Scene {
         background = new Background(Settings.WINDOW_WIDTH, Settings.WINDOW_HEIGHT);
 
         // 3. create lives display via entity manager
-        livesDisplay = (LivesDisplay) entityMutator.createEntity(() -> new LivesDisplay(INITIAL_LIVES));
+        livesDisplay = (LivesDisplay) context.entities().createEntity(() -> new LivesDisplay(INITIAL_LIVES));
 
         // 4. create score display via entity manager
-        scoreDisplay = (ScoreDisplay) entityMutator.createEntity(
+        scoreDisplay = (ScoreDisplay) context.entities().createEntity(
             () -> new ScoreDisplay(520f, Settings.WINDOW_HEIGHT - 10f, 0)
         );
 
         // 5. create bucket via entity manager
         float bucketX = (Settings.WINDOW_WIDTH / 2f) - (Bucket.BUCKET_WIDTH / 2f);
         float bucketY = 20f;
-        bucket = (Bucket) entityMutator.createEntity(() -> new Bucket(bucketX, bucketY));
+        bucket = (Bucket) context.entities().createEntity(() -> new Bucket(bucketX, bucketY));
 
         // 6. register bucket with managers
         movementManager.registerMovable(bucket);
@@ -128,10 +124,10 @@ public class GameScene extends Scene {
         bucket.setCatchHandler(this::handleDropletCatch);
 
         // 7. create and register cloud deflectors
-        createClouds();
+        createClouds(context.entities());
 
         // 8. spawn initial droplet
-        spawnDroplet();
+        spawnDroplet(context.entities());
     }
 
     @Override
@@ -148,14 +144,14 @@ public class GameScene extends Scene {
         if (bucket != null) {
             movementManager.unregisterMovable(bucket);
             collisionManager.unregisterCollidable(bucket);
-            entityMutator.removeEntity(bucket.getId());
+            context.entities().removeEntity(bucket.getId());
         }
 
         // clean up remaining droplets
         for (int i = 0; i < droplets.size; i++) {
             Droplet droplet = droplets.get(i);
             collisionManager.unregisterCollidable(droplet);
-            entityMutator.removeEntity(droplet.getId());
+            context.entities().removeEntity(droplet.getId());
         }
         droplets.clear();
 
@@ -163,19 +159,19 @@ public class GameScene extends Scene {
         for (int i = 0; i < clouds.size; i++) {
             Cloud cloud = clouds.get(i);
             collisionManager.unregisterCollidable(cloud);
-            entityMutator.removeEntity(cloud.getId());
+            context.entities().removeEntity(cloud.getId());
         }
         clouds.clear();
 
         // remove lives display entity
         if (livesDisplay != null) {
-            entityMutator.removeEntity(livesDisplay.getId());
+            context.entities().removeEntity(livesDisplay.getId());
         }
 
         // remove score display entity
         if (scoreDisplay != null) {
             scoreDisplay.dispose();
-            entityMutator.removeEntity(scoreDisplay.getId());
+            context.entities().removeEntity(scoreDisplay.getId());
         }
     }
 
@@ -229,7 +225,7 @@ public class GameScene extends Scene {
         // 2. update spawn timer and spawn new droplets
         spawnTimer += deltaTime;
         if (spawnTimer >= SPAWN_INTERVAL && droplets.size < MAX_DROPLETS) {
-            spawnDroplet();
+            spawnDroplet(context.entities());
             spawnTimer = 0f;
         }
 
@@ -258,7 +254,7 @@ public class GameScene extends Scene {
             // check if caught
             if (droplet.isCaught()) {
                 // remove entity
-                entityMutator.removeEntity(droplet.getId());
+                context.entities().removeEntity(droplet.getId());
 
                 // unregister from collision manager
                 collisionManager.unregisterCollidable(droplet);
@@ -275,7 +271,7 @@ public class GameScene extends Scene {
                 livesDisplay.setLives(currentLives - 1);
 
                 // remove entity
-                entityMutator.removeEntity(droplet.getId());
+                context.entities().removeEntity(droplet.getId());
 
                 // unregister from collision manager
                 collisionManager.unregisterCollidable(droplet);
@@ -325,10 +321,12 @@ public class GameScene extends Scene {
 
     /**
      * spawns a new droplet at a random x position at the top of the screen.
+     *
+     * @param mutator the entity mutator for creating entities
      */
-    private void spawnDroplet() {
+    private void spawnDroplet(IEntityMutator mutator) {
         float x = randomX();
-        Droplet droplet = (Droplet) entityMutator.createEntity(() -> new Droplet(x, SPAWN_Y));
+        Droplet droplet = (Droplet) mutator.createEntity(() -> new Droplet(x, SPAWN_Y));
 
         // add to array
         droplets.add(droplet);
@@ -368,24 +366,26 @@ public class GameScene extends Scene {
     /**
      * creates three cloud deflectors positioned to create obstacles
      * for falling droplets.
+     *
+     * @param mutator the entity mutator for creating entities
      */
-    private void createClouds() {
+    private void createClouds(IEntityMutator mutator) {
         // left cloud
-        Cloud leftCloud = (Cloud) entityMutator.createEntity(
+        Cloud leftCloud = (Cloud) mutator.createEntity(
             () -> new Cloud(60f, 400f)
         );
         clouds.add(leftCloud);
         collisionManager.registerCollidable(leftCloud);
 
         // right cloud
-        Cloud rightCloud = (Cloud) entityMutator.createEntity(
+        Cloud rightCloud = (Cloud) mutator.createEntity(
             () -> new Cloud(414f, 400f)
         );
         clouds.add(rightCloud);
         collisionManager.registerCollidable(rightCloud);
 
         // middle cloud (below the others)
-        Cloud middleCloud = (Cloud) entityMutator.createEntity(
+        Cloud middleCloud = (Cloud) mutator.createEntity(
             () -> new Cloud(242f, 300f)
         );
         clouds.add(middleCloud);

--- a/core/src/main/java/com/p1_7/demo/scenes/PauseScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/PauseScene.java
@@ -3,7 +3,6 @@ package com.p1_7.demo.scenes;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
-import com.p1_7.abstractengine.entity.IEntityMutator;
 import com.p1_7.abstractengine.scene.Scene;
 import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.demo.Settings;
@@ -49,17 +48,11 @@ public class PauseScene extends Scene {
     /** current score to display */
     private int currentScore = 0;
 
-    /** entity mutator for creating entities */
-    private final IEntityMutator entityMutator;
-
     /**
      * constructs a pause scene.
-     *
-     * @param entityMutator the entity mutator for creation and removal
      */
-    public PauseScene(IEntityMutator entityMutator) {
+    public PauseScene() {
         this.name = "pause";
-        this.entityMutator = entityMutator;
     }
 
     /**
@@ -116,7 +109,7 @@ public class PauseScene extends Scene {
         // 6. create volume slider
         float sliderX = Settings.WINDOW_WIDTH / 2f - 100f;
         float sliderY = Settings.WINDOW_HEIGHT * 0.27f;
-        volumeSlider = (VolumeSlider) entityMutator.createEntity(
+        volumeSlider = (VolumeSlider) context.entities().createEntity(
             () -> new VolumeSlider(sliderX, sliderY, 200f)
         );
 
@@ -138,7 +131,7 @@ public class PauseScene extends Scene {
 
         // remove volume slider entity
         if (volumeSlider != null) {
-            entityMutator.removeEntity(volumeSlider.getId());
+            context.entities().removeEntity(volumeSlider.getId());
         }
     }
 


### PR DESCRIPTION
## Issue

`SceneContext.entities()` returned `IEntityRepository`, giving scenes read-only access to the entity store. Because there was no write path  through `SceneContext`, `GameScene` and `PauseScene` each accepted `IEntityMutator` as a direct constructor parameter, bypassing the context entirely and coupling scene construction in `Main` to an implementation detail of the entity system.

## Solution

A new `IEntityManager` interface is introduced that extends both `IEntityRepository` and `IEntityMutator`, unifying read and write access behind a single contract. `EntityManager` now implements `IEntityManager`. `SceneContext.entities()` is widened to return `IEntityManager`, and `SceneManager` is updated to accept and hold `IEntityManager` instead of `IEntityRepository`.

With the write path available through `context.entities()`, the `IEntityMutator` constructor parameters are removed from `GameScene` and `PauseScene`, and all entity creation and removal calls are routed through the context.