### PR TITLE
refactor: trim abstractengine Javadoc to contract-focused standard

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/collision/CollisionDetector.java
+++ b/core/src/main/java/com/p1_7/abstractengine/collision/CollisionDetector.java
@@ -1,11 +1,7 @@
 package com.p1_7.abstractengine.collision;
 
 /**
- * stateless utility that checks whether two ICollidable
- * objects overlap.
- *
- * the check is performed by delegating to the IBounds.overlaps()
- * method on the bounds returned by each collidable.
+ * stateless utility that tests two ICollidable objects for overlap.
  */
 public class CollisionDetector {
 

--- a/core/src/main/java/com/p1_7/abstractengine/collision/CollisionManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/collision/CollisionManager.java
@@ -5,21 +5,8 @@ import com.badlogic.gdx.utils.Array;
 import com.p1_7.abstractengine.engine.UpdatableManager;
 
 /**
- * abstract per-frame manager that tests all registered ICollidable
- * entities for pairwise overlap using a two-phase architecture:
- * detection followed by resolution.
- *
- * entities must be explicitly registered via
- * registerCollidable(ICollidable). the detection phase uses a
- * stateless CollisionDetector and iterates unique pairs (O(n²))
- * to identify all collisions in the current frame. the resolution phase
- * processes these detected collisions according to the strategy implemented
- * by concrete subclasses.
- *
- * subclasses can override detect() to implement optimised
- * detection algorithms (spatial partitioning, grid-based, etc.) and must
- * implement resolve(Array) to define collision resolution behaviour
- * (callbacks, physics impulses, layered filtering, etc.).
+ * abstract per-frame manager that tests all registered ICollidable entities
+ * for pairwise overlap and delegates resolution to concrete subclasses.
  */
 public abstract class CollisionManager extends UpdatableManager {
 
@@ -31,10 +18,6 @@ public abstract class CollisionManager extends UpdatableManager {
 
     /** detected collisions from the current frame */
     private final Array<CollisionPair> detectedCollisions = new Array<>();
-
-    // ---------------------------------------------------------------
-    // registration
-    // ---------------------------------------------------------------
 
     /**
      * adds an ICollidable to the detection list.
@@ -54,10 +37,6 @@ public abstract class CollisionManager extends UpdatableManager {
         collidables.removeValue(collidable, true);
     }
 
-    // ---------------------------------------------------------------
-    // UpdatableManager hook
-    // ---------------------------------------------------------------
-
     /**
      * runs collision detection and resolution in two phases:
      * first detects all collisions, then resolves them.
@@ -70,18 +49,8 @@ public abstract class CollisionManager extends UpdatableManager {
         resolve(detectedCollisions);
     }
 
-    // ---------------------------------------------------------------
-    // detection & resolution
-    // ---------------------------------------------------------------
-
     /**
-     * detects all collisions by iterating unique pairs (i, j) where
-     * i < j. detected collisions are stored in detectedCollisions
-     * for processing by resolve(Array).
-     *
-     * this method clears the previous frame's collisions before detection.
-     * subclasses can override this method to implement optimised detection
-     * algorithms (spatial partitioning, quadtrees, etc.).
+     * detects all collisions for the current frame by iterating unique pairs.
      */
     protected void detect() {
         detectedCollisions.clear();
@@ -97,14 +66,7 @@ public abstract class CollisionManager extends UpdatableManager {
     }
 
     /**
-     * resolves detected collisions according to the collision resolution
-     * strategy implemented by concrete subclasses.
-     *
-     * examples of resolution strategies include:
-     * 1. callback-based: invoke ICollidable.onCollision(ICollidable) on both entities
-     * 2. physics-based: apply impulses or forces to separate entities
-     * 3. layered: filter collisions based on entity groups or categories
-     * 4. batched: group collisions by type and handle differently
+     * resolves detected collisions for the current frame.
      *
      * @param collisions the array of detected collision pairs from this frame
      */

--- a/core/src/main/java/com/p1_7/abstractengine/collision/IBounds.java
+++ b/core/src/main/java/com/p1_7/abstractengine/collision/IBounds.java
@@ -1,26 +1,13 @@
 package com.p1_7.abstractengine.collision;
 
 /**
- * dimension-agnostic collision boundary for an entity.
- *
- * all spatial data is expressed as plain float[] arrays. the length
- * of each array is determined by the concrete implementation; the
- * abstract engine does not assume any particular dimensionality.
- * demo code that targets 2-D will use arrays of length 2.
- *
- * implementations define both the shape representation and the
- * overlap detection logic. examples include axis-aligned rectangles,
- * circles, polygons, and 3D bounding volumes.
+ * dimension-agnostic collision boundary for an entity; array lengths are
+ * determined by the concrete implementation.
  */
 public interface IBounds {
 
     /**
      * determines whether this bounds overlaps with another bounds.
-     *
-     * implementations must handle checking against different bounds
-     * types. for example, a Rectangle2D must detect overlap with
-     * both other Rectangle2D instances and potentially Circle2D
-     * instances.
      *
      * @param other the bounds to check against; must not be null
      * @return true if the bounds overlap, false otherwise
@@ -30,19 +17,12 @@ public interface IBounds {
     /**
      * returns the minimum corner position as a float array.
      *
-     * for 2D axis-aligned rectangles, this is the bottom-left corner
-     * (x, y). for 3D axis-aligned boxes, this is the minimum corner
-     * (x, y, z).
-     *
      * @return the minimum position vector; length equals the number of dimensions
      */
     float[] getMinPosition();
 
     /**
      * returns the extent (size) in each dimension as a float array.
-     *
-     * for 2D rectangles, this is (width, height). for 3D boxes, this
-     * is (width, height, depth).
      *
      * @return the size vector; length equals the number of dimensions
      */
@@ -51,9 +31,6 @@ public interface IBounds {
     /**
      * updates the bounds to the specified minimum position and extent.
      *
-     * this method is used to sync cached bounds instances with entity
-     * transforms without creating new objects each frame.
-     *
      * @param minPosition the new minimum corner position
      * @param extent the new size in each dimension
      */
@@ -61,9 +38,6 @@ public interface IBounds {
 
     /**
      * returns the number of spatial dimensions this bounds operates in.
-     *
-     * concrete implementations decide the value; demo code will typically
-     * return 2.
      *
      * @return the dimensionality (length of position and extent arrays)
      */

--- a/core/src/main/java/com/p1_7/abstractengine/collision/ICollidable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/collision/ICollidable.java
@@ -1,23 +1,12 @@
 package com.p1_7.abstractengine.collision;
 
 /**
- * capability interface for any entity that participates in collision
- * detection.
- *
- * the bounding volume returned by getBounds() is used by
- * CollisionDetector to perform overlap tests. the
- * onCollision(ICollidable) callback is invoked by the
- * CollisionManager when an overlap is detected with another
- * collidable.
+ * capability interface for any entity that participates in collision detection.
  */
 public interface ICollidable {
 
     /**
      * returns the collision bounds that represent this entity's shape.
-     *
-     * implementations may return axis-aligned rectangles, circles,
-     * polygons, or other shapes depending on their dimensionality
-     * and collision requirements.
      *
      * @return the bounding volume; must not be null
      */

--- a/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
@@ -4,14 +4,8 @@ import com.badlogic.gdx.utils.Array;
 import com.p1_7.abstractengine.render.RenderManager;
 
 /**
- * central orchestrator for the abstract engine. manages the lifecycle
- * and per-frame update of all registered IManager and
- * IUpdatable instances, and delegates the explicit render call
- * to the RenderManager.
- *
- * managers are initialised in registration order and shut down in
- * reverse order so that dependencies are torn down after the objects
- * that depend on them.
+ * central orchestrator that manages manager lifecycles, drives the update loop,
+ * and delegates the per-frame render call.
  */
 public class Engine {
 
@@ -47,9 +41,7 @@ public class Engine {
     }
 
     /**
-     * stores the render manager for the explicit render step. the
-     * engine calls RenderManager.render() once per frame
-     * separately from the update loop.
+     * stores the render manager for the explicit per-frame render step.
      *
      * @param renderManager the render manager instance
      * @throws IllegalArgumentException if renderManager is null

--- a/core/src/main/java/com/p1_7/abstractengine/engine/IManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/IManager.java
@@ -1,11 +1,8 @@
 package com.p1_7.abstractengine.engine;
 
 /**
- * core lifecycle contract for every manager in the abstract engine.
- *
- * implementations are responsible for allocating and releasing any
- * resources they hold during init() and shutdown()
- * respectively.
+ * lifecycle contract for every manager; implementations allocate resources
+ * in init() and release them in shutdown().
  */
 public interface IManager {
 

--- a/core/src/main/java/com/p1_7/abstractengine/engine/IUpdatable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/IUpdatable.java
@@ -2,9 +2,6 @@ package com.p1_7.abstractengine.engine;
 
 /**
  * contract for any object that must be updated once per frame.
- *
- * the engine iterates all registered IUpdatable instances
- * each frame, passing the elapsed time since the previous frame.
  */
 public interface IUpdatable {
 

--- a/core/src/main/java/com/p1_7/abstractengine/engine/Manager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/Manager.java
@@ -1,14 +1,8 @@
 package com.p1_7.abstractengine.engine;
 
 /**
- * abstract base class that provides the standard lifecycle template for
- * all managers in the engine.
- *
- * subclasses override onInit() and onShutdown() to
- * perform their own setup and teardown. the public init() and
- * shutdown() methods are final and must not be
- * overridden - they manage the isInitialised() flag and then
- * delegate to the hooks.
+ * abstract base class providing the standard init/shutdown lifecycle template
+ * for all managers.
  */
 public abstract class Manager implements IManager {
 
@@ -16,8 +10,7 @@ public abstract class Manager implements IManager {
     private boolean initialised;
 
     /**
-     * initialises the manager. sets the initialised flag and delegates
-     * to onInit().
+     * initialises the manager.
      */
     @Override
     public final void init() {
@@ -26,8 +19,7 @@ public abstract class Manager implements IManager {
     }
 
     /**
-     * shuts down the manager. delegates to onShutdown() and
-     * clears the initialised flag.
+     * shuts down the manager.
      */
     @Override
     public final void shutdown() {
@@ -36,16 +28,14 @@ public abstract class Manager implements IManager {
     }
 
     /**
-     * hook called during initialisation. override in subclasses to
-     * perform setup work. default implementation is a no-op.
+     * override to perform setup work; default is a no-op.
      */
     protected void onInit() {
         // no-op — subclasses may override
     }
 
     /**
-     * hook called during shutdown. override in subclasses to release
-     * resources. default implementation is a no-op.
+     * override to release resources; default is a no-op.
      */
     protected void onShutdown() {
         // no-op — subclasses may override
@@ -54,8 +44,7 @@ public abstract class Manager implements IManager {
     /**
      * returns whether this manager has been initialised.
      *
-     * @return true if init() has been called and
-     *         shutdown() has not yet been called
+     * @return true if the manager is currently initialised
      */
     public boolean isInitialised() {
         return initialised;

--- a/core/src/main/java/com/p1_7/abstractengine/engine/UpdatableManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/UpdatableManager.java
@@ -1,18 +1,13 @@
 package com.p1_7.abstractengine.engine;
 
 /**
- * abstract manager that participates in the per-frame update loop in
- * addition to the standard lifecycle provided by Manager.
- *
- * subclasses implement onUpdate(float) to define their
- * frame-tick behaviour. the public update(float) method is
- * final and delegates directly to that hook.
+ * abstract manager that also participates in the per-frame update loop;
+ * subclasses implement onUpdate(float) for their tick logic.
  */
 public abstract class UpdatableManager extends Manager implements IUpdatable {
 
     /**
-     * called once per frame by the engine. delegates to
-     * onUpdate(float).
+     * advances the manager by one frame.
      *
      * @param deltaTime seconds elapsed since the previous frame
      */

--- a/core/src/main/java/com/p1_7/abstractengine/entity/Entity.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/Entity.java
@@ -3,12 +3,8 @@ package com.p1_7.abstractengine.entity;
 import java.util.UUID;
 
 /**
- * abstract base class for every entity managed by the engine.
- *
- * each entity is assigned a globally unique identifier at
- * construction time and is active by default. concrete subclasses
- * (created during the demo phase) extend this class to attach
- * transform, movability, collidability and other capabilities.
+ * abstract base class for every entity managed by the engine; assigned a
+ * globally unique identifier at construction and active by default.
  */
 public abstract class Entity {
 
@@ -19,8 +15,7 @@ public abstract class Entity {
     private boolean active;
 
     /**
-     * constructs a new entity with a randomly generated UUID and
-     * active set to true.
+     * constructs a new entity with a randomly generated UUID.
      */
     protected Entity() {
         this.id = UUID.randomUUID();

--- a/core/src/main/java/com/p1_7/abstractengine/entity/EntityFactory.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/EntityFactory.java
@@ -1,13 +1,8 @@
 package com.p1_7.abstractengine.entity;
 
 /**
- * functional interface that decouples the EntityManager from
- * any concrete Entity subclass.
- *
- * the demo phase supplies a concrete implementation - typically a
- * lambda or method reference - that constructs the desired entity
- * type. the manager calls create() and takes ownership of
- * the returned instance.
+ * functional interface that decouples the EntityManager from any concrete
+ * Entity subclass.
  */
 @FunctionalInterface
 public interface EntityFactory {

--- a/core/src/main/java/com/p1_7/abstractengine/entity/EntityManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/EntityManager.java
@@ -6,20 +6,13 @@ import com.badlogic.gdx.utils.Array;
 import com.p1_7.abstractengine.engine.Manager;
 
 /**
- * manages the lifecycle of all entities in the engine. acts as the
- * unified entity manager (IEntityManager), providing both the
- * read-only repository and the write-side mutator contracts.
- *
- * this manager has no per-frame update logic of its own.
+ * concrete entity manager providing both the read-only repository and
+ * write-side mutator contracts.
  */
 public class EntityManager extends Manager implements IEntityManager {
 
     /** the backing store of all live entities */
     private final Array<Entity> entities = new Array<>();
-
-    // ---------------------------------------------------------------
-    // IEntityMutator
-    // ---------------------------------------------------------------
 
     /**
      * creates an entity via the supplied factory, adds it to the internal store, and returns it.
@@ -36,7 +29,6 @@ public class EntityManager extends Manager implements IEntityManager {
 
     /**
      * sets the active flag on the entity identified by id.
-     * performs a linear scan of the entity array.
      *
      * @param id     the UUID of the target entity
      * @param active the desired active state
@@ -52,7 +44,7 @@ public class EntityManager extends Manager implements IEntityManager {
     }
 
     /**
-     * removes the entity identified by id. performs a linear scan and removes by index.
+     * removes the entity identified by id from the store.
      *
      * @param id the UUID of the entity to remove
      */
@@ -66,12 +58,8 @@ public class EntityManager extends Manager implements IEntityManager {
         }
     }
 
-    // ---------------------------------------------------------------
-    // IEntityRepository
-    // ---------------------------------------------------------------
-
     /**
-     * retrieves a single entity by its unique identifier. performs a linear scan.
+     * retrieves a single entity by its unique identifier.
      *
      * @param id the UUID to look up
      * @return the matching entity, or null if not found
@@ -87,7 +75,7 @@ public class EntityManager extends Manager implements IEntityManager {
     }
 
     /**
-     * builds and returns a new Array containing the UUIDs of every entity in the store.
+     * returns the UUIDs of every entity in the store.
      *
      * @return an Array of all entity identifiers
      */
@@ -100,14 +88,8 @@ public class EntityManager extends Manager implements IEntityManager {
         return ids;
     }
 
-    // ---------------------------------------------------------------
-    // diagnostics
-    // ---------------------------------------------------------------
-
     /**
-     * returns a debug string listing the UUIDs of all entities currently in the store.
-     *
-     * @return a human-readable summary of the entity store
+     * returns a debug string listing the UUIDs of all entities.
      */
     @Override
     public String toString() {

--- a/core/src/main/java/com/p1_7/abstractengine/entity/IEntityManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/IEntityManager.java
@@ -1,12 +1,7 @@
 package com.p1_7.abstractengine.entity;
 
 /**
- * unified contract for the entity store, combining read and write access.
- *
- * code that needs both querying and mutation receives this interface.
- * read-only access is available through IEntityRepository; write-only
- * access is available through IEntityMutator. implementations may
- * selectively fulfil either or both contracts based on their needs.
+ * unified entity store contract combining read and write access.
  */
 public interface IEntityManager extends IEntityRepository, IEntityMutator {
 }

--- a/core/src/main/java/com/p1_7/abstractengine/entity/IEntityMutator.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/IEntityMutator.java
@@ -3,12 +3,8 @@ package com.p1_7.abstractengine.entity;
 import java.util.UUID;
 
 /**
- * write-side contract for the entity store.
- *
- * code that needs to add, update or remove entities receives this
- * interface. read-only access is provided by IEntityRepository.
- * ownership of an entity moves to the manager once
- * createEntity(EntityFactory) returns.
+ * write-side contract for the entity store; read-only access is provided
+ * by IEntityRepository.
  */
 public interface IEntityMutator {
 

--- a/core/src/main/java/com/p1_7/abstractengine/entity/IEntityRepository.java
+++ b/core/src/main/java/com/p1_7/abstractengine/entity/IEntityRepository.java
@@ -3,11 +3,8 @@ package com.p1_7.abstractengine.entity;
 import java.util.UUID;
 
 /**
- * read-only view of the entity store.
- *
- * scene and rendering code receives this interface so that it can
- * query entities without being able to mutate the store directly.
- * write operations are exposed through IEntityMutator.
+ * read-only view of the entity store for querying entities without
+ * mutating the store.
  */
 public interface IEntityRepository {
 

--- a/core/src/main/java/com/p1_7/abstractengine/input/ActionId.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/ActionId.java
@@ -3,16 +3,8 @@ package com.p1_7.abstractengine.input;
 import java.util.Objects;
 
 /**
- * represents a logical input action recognised by the engine.
- *
- * this class uses a string-based identifier system, allowing game
- * code to define custom actions without modifying the core engine.
- * demo implementations can create their own action constants
- * (e.g., new ActionId("LEFT")) and bind them via
- * InputMapping.
- *
- * the engine provides a single default action, NONE,
- * for compatibility with stub code.
+ * represents a logical input action recognised by the engine, identified
+ * by a unique string.
  */
 public class ActionId {
 

--- a/core/src/main/java/com/p1_7/abstractengine/input/IInputQuery.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/IInputQuery.java
@@ -2,10 +2,6 @@ package com.p1_7.abstractengine.input;
 
 /**
  * read-only query interface for the current frame's input state.
- *
- * scenes and other engine components receive this interface so
- * that they can interrogate input without coupling to the
- * InputManager directly.
  */
 public interface IInputQuery {
 

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputEvent.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputEvent.java
@@ -1,13 +1,8 @@
 package com.p1_7.abstractengine.input;
 
 /**
- * abstract base class for all input events produced by the engine.
- *
- * concrete event types (digital, analogue, pointer, etc.) are
- * context-specific and belong in the demo phase. this class defines
- * the fields and accessors that every event shares: the logical
- * ActionId that triggered it and the system timestamp at
- * which it occurred.
+ * abstract base class for all input events; carries the triggering ActionId
+ * and a system timestamp.
  */
 public abstract class InputEvent {
 

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputManager.java
@@ -8,15 +8,8 @@ import com.badlogic.gdx.utils.ObjectSet;
 import com.p1_7.abstractengine.engine.UpdatableManager;
 
 /**
- * manages per-frame input polling and exposes the resulting action
- * states via IInputQuery.
- *
- * each frame the manager iterates every value in ActionId,
- * checks whether any bound key or button is physically pressed, and
- * derives the frame-local transition state (InputState)
- * relative to the previous frame. the entire pipeline is dormant
- * until ActionId is populated with real values and bindings
- * are added to the InputMapping.
+ * polls physical input devices each frame and exposes derived action states
+ * via IInputQuery.
  */
 public class InputManager extends UpdatableManager implements IInputQuery {
 
@@ -32,10 +25,6 @@ public class InputManager extends UpdatableManager implements IInputQuery {
     /** whether each action was physically down last frame */
     private final ObjectMap<ActionId, Boolean> previousDown = new ObjectMap<>();
 
-    // ---------------------------------------------------------------
-    // UpdatableManager hook
-    // ---------------------------------------------------------------
-
     /**
      * polls the physical input devices and computes the logical
      * action-state transitions for this frame.
@@ -49,17 +38,12 @@ public class InputManager extends UpdatableManager implements IInputQuery {
             return;
         }
 
-        // collect all unique action ids from the input mapping
         ObjectSet<ActionId> boundActions = getBoundActions();
 
         for (ActionId action : boundActions) {
-            // determine whether any bound physical input is down
             boolean currentlyDown = isPhysicallyDown(action);
-
-            // retrieve the state from last frame (defaults to false)
             boolean wasDown = previousDown.get(action, false);
 
-            // derive the transition and store it
             if (currentlyDown && !wasDown) {
                 actionStates.put(action, InputState.PRESSED);
             } else if (currentlyDown && wasDown) {
@@ -67,18 +51,12 @@ public class InputManager extends UpdatableManager implements IInputQuery {
             } else if (!currentlyDown && wasDown) {
                 actionStates.put(action, InputState.RELEASED);
             } else {
-                // not active this frame — remove any stale entry
                 actionStates.remove(action);
             }
 
-            // record the raw state for next frame
             previousDown.put(action, currentlyDown);
         }
     }
-
-    // ---------------------------------------------------------------
-    // IInputQuery
-    // ---------------------------------------------------------------
 
     /**
      * returns whether the specified action is currently active
@@ -104,10 +82,6 @@ public class InputManager extends UpdatableManager implements IInputQuery {
         return actionStates.get(actionId);
     }
 
-    // ---------------------------------------------------------------
-    // accessors
-    // ---------------------------------------------------------------
-
     /**
      * returns the input mapping used by this manager.
      *
@@ -118,9 +92,7 @@ public class InputManager extends UpdatableManager implements IInputQuery {
     }
 
     /**
-     * enables or disables input polling. when disabled,
-     * actionStates is cleared each frame so that all
-     * queries return inactive.
+     * enables or disables input polling.
      *
      * @param enabled true to enable polling
      */
@@ -128,13 +100,8 @@ public class InputManager extends UpdatableManager implements IInputQuery {
         this.inputEnabled = enabled;
     }
 
-    // ---------------------------------------------------------------
-    // private helpers
-    // ---------------------------------------------------------------
-
     /**
-     * collects all unique action ids that have been bound to at least
-     * one key or button in the input mapping.
+     * returns all action ids that have at least one key or button binding.
      *
      * @return an ObjectSet of all bound actions
      */
@@ -143,15 +110,12 @@ public class InputManager extends UpdatableManager implements IInputQuery {
     }
 
     /**
-     * checks whether any physical key or button bound to the given
-     * action is currently held down, using the reverse-lookup helpers
-     * on the InputMapping.
+     * returns true if any physical key or button bound to the action is currently held.
      *
      * @param action the logical action to check
      * @return true if at least one bound input is pressed
      */
     private boolean isPhysicallyDown(ActionId action) {
-        // check all bound keyboard keys
         Array<Integer> keys = inputMapping.getKeysForAction(action);
         for (int i = 0; i < keys.size; i++) {
             if (Gdx.input.isKeyPressed(keys.get(i))) {
@@ -159,7 +123,6 @@ public class InputManager extends UpdatableManager implements IInputQuery {
             }
         }
 
-        // check all bound controller buttons
         Array<Integer> buttons = inputMapping.getButtonsForAction(action);
         for (int i = 0; i < buttons.size; i++) {
             if (Gdx.input.isButtonPressed(buttons.get(i))) {

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputMapping.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputMapping.java
@@ -5,13 +5,8 @@ import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.ObjectSet;
 
 /**
- * maintains the mapping between physical input codes (keyboard keys,
+ * maintains the mapping between physical input codes (keyboard keys and
  * controller buttons) and logical ActionId values.
- *
- * no bindings are populated by default because ActionId
- * currently contains only the placeholder ActionId.NONE.
- * the demo phase will call bindKey(int, ActionId) and
- * bindButton(int, ActionId) to wire up real controls.
  */
 public class InputMapping {
 
@@ -21,27 +16,17 @@ public class InputMapping {
     /** maps controller button codes to logical actions */
     private final ObjectMap<Integer, ActionId> buttonBindings = new ObjectMap<>();
 
-    /**
-     * constructs an InputMapping and initialises it to the
-     * default (empty) state.
-     */
     public InputMapping() {
         resetToDefaults();
     }
 
     /**
-     * clears all key and button bindings. called automatically by the
-     * constructor; the demo phase will re-populate bindings after
-     * ActionId gains meaningful values.
+     * clears all key and button bindings.
      */
     public void resetToDefaults() {
         keyBindings.clear();
         buttonBindings.clear();
     }
-
-    // ---------------------------------------------------------------
-    // forward lookups
-    // ---------------------------------------------------------------
 
     /**
      * returns the logical action bound to the given keyboard key code.
@@ -63,10 +48,6 @@ public class InputMapping {
     public ActionId getActionForButton(int buttonCode) {
         return buttonBindings.get(buttonCode);
     }
-
-    // ---------------------------------------------------------------
-    // binding
-    // ---------------------------------------------------------------
 
     /**
      * binds a keyboard key to a logical action.
@@ -96,13 +77,8 @@ public class InputMapping {
         buttonBindings.put(buttonCode, actionId);
     }
 
-    // ---------------------------------------------------------------
-    // reverse lookups
-    // ---------------------------------------------------------------
-
     /**
-     * scans the key-binding map and returns every key code that is
-     * mapped to the supplied action.
+     * returns every key code mapped to the supplied action.
      *
      * @param actionId the action to search for
      * @return an Array of matching key codes (may be empty)
@@ -118,8 +94,7 @@ public class InputMapping {
     }
 
     /**
-     * scans the button-binding map and returns every button code that
-     * is mapped to the supplied action.
+     * returns every button code mapped to the supplied action.
      *
      * @param actionId the action to search for
      * @return an Array of matching button codes (may be empty)
@@ -135,22 +110,19 @@ public class InputMapping {
     }
 
     /**
-     * returns all unique action ids that have been bound to at least
-     * one key or button.
+     * returns all unique action ids that have at least one binding.
      *
      * @return an ObjectSet of all bound actions
      */
     public ObjectSet<ActionId> getAllActions() {
         ObjectSet<ActionId> actions = new ObjectSet<>();
 
-        // collect from key bindings
         for (ObjectMap.Entry<Integer, ActionId> entry : keyBindings) {
             if (entry.value != null) {
                 actions.add(entry.value);
             }
         }
 
-        // collect from button bindings
         for (ObjectMap.Entry<Integer, ActionId> entry : buttonBindings) {
             if (entry.value != null) {
                 actions.add(entry.value);

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputState.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputState.java
@@ -1,12 +1,7 @@
 package com.p1_7.abstractengine.input;
 
 /**
- * represents the discrete state of a logical input action within a
- * single frame.
- *
- * - PRESSED - the action transitioned from inactive to active this frame.
- * - HELD - the action was already active last frame and remains active.
- * - RELEASED - the action transitioned from active to inactive this frame.
+ * the discrete per-frame state of a logical input action.
  */
 public enum InputState {
 

--- a/core/src/main/java/com/p1_7/abstractengine/movement/IMovable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/movement/IMovable.java
@@ -1,14 +1,8 @@
 package com.p1_7.abstractengine.movement;
 
 /**
- * capability interface for any entity that can move under the
- * influence of acceleration and velocity.
- *
- * all vectors are plain float[] arrays whose length matches
- * the dimensionality of the owning entity's
- * com.p1_7.abstractengine.transform.ITransform. the abstract
- * engine does not mandate 2-D; concrete implementations decide the
- * array length.
+ * capability interface for any entity that moves under the influence of
+ * acceleration and velocity; vector lengths match the entity's transform dimensionality.
  */
 public interface IMovable {
 
@@ -41,9 +35,7 @@ public interface IMovable {
     void setVelocity(float[] velocity);
 
     /**
-     * advances the entity by one physics step. concrete
-     * implementations apply acceleration to velocity, then velocity
-     * to position.
+     * advances the entity by one physics step.
      *
      * @param deltaTime seconds elapsed since the previous frame
      */

--- a/core/src/main/java/com/p1_7/abstractengine/movement/MovementManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/movement/MovementManager.java
@@ -7,15 +7,8 @@ import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.abstractengine.transform.ITransformable;
 
 /**
- * per-frame manager that advances all registered IMovable
- * entities and, optionally, clamps their positions to a set of
- * world-space boundaries.
- *
- * entities must be explicitly registered via
- * registerMovable(IMovable) before they will be updated.
- * boundary clamping is dimension-agnostic: the demo calls
- * setWorldBounds(float[], float[]) with arrays whose length
- * matches the entities' ITransform.getDimensions().
+ * per-frame manager that advances all registered IMovable entities and
+ * optionally clamps their positions to world-space boundaries.
  */
 public class MovementManager extends UpdatableManager {
 
@@ -30,10 +23,6 @@ public class MovementManager extends UpdatableManager {
 
     /** per-dimension upper bound (exclusive before size offset); null until set */
     private float[] boundsMax;
-
-    // ---------------------------------------------------------------
-    // registration
-    // ---------------------------------------------------------------
 
     /**
      * adds an IMovable to the update list.
@@ -53,10 +42,6 @@ public class MovementManager extends UpdatableManager {
         movables.removeValue(movable, true);
     }
 
-    // ---------------------------------------------------------------
-    // configuration
-    // ---------------------------------------------------------------
-
     /**
      * enables or disables boundary clamping after movement.
      *
@@ -67,16 +52,11 @@ public class MovementManager extends UpdatableManager {
     }
 
     /**
-     * sets the per-dimension world-space boundaries. the demo
-     * typically passes arrays derived from com.p1_7.abstractengine.engine.Settings
-     * (e.g. min = {0, 0}, max = {WINDOW_WIDTH, WINDOW_HEIGHT}).
-     * both arrays must be the same length; the engine does not enforce
-     * a specific dimensionality.
+     * sets the per-dimension world-space boundaries used for position clamping.
      *
      * @param min the lower bounds per dimension
      * @param max the upper bounds per dimension
-     * @throws IllegalArgumentException if min or max is null, arrays have different lengths,
-     *                                  arrays are empty, or any min[i] > max[i]
+     * @throws IllegalArgumentException if arrays are null, mismatched, empty, or min[i] > max[i]
      */
     public void setWorldBounds(float[] min, float[] max) {
         if (min == null) {
@@ -102,10 +82,6 @@ public class MovementManager extends UpdatableManager {
         this.boundsMax = max;
     }
 
-    // ---------------------------------------------------------------
-    // UpdatableManager hook
-    // ---------------------------------------------------------------
-
     /**
      * advances every registered movable by one physics step, then
      * clamps positions to the world bounds if enabled.
@@ -117,20 +93,14 @@ public class MovementManager extends UpdatableManager {
         for (int i = 0; i < movables.size; i++) {
             IMovable movable = movables.get(i);
 
-            // step the physics
             movable.move(deltaTime);
 
-            // clamp to world bounds if all conditions are met
             if (boundariesEnabled && boundsMin != null && boundsMax != null
                     && movable instanceof ITransformable) {
                 clampToBounds((ITransformable) movable);
             }
         }
     }
-
-    // ---------------------------------------------------------------
-    // private helpers
-    // ---------------------------------------------------------------
 
     /**
      * clamps each dimension of the entity's position so that the
@@ -146,17 +116,14 @@ public class MovementManager extends UpdatableManager {
         int dimensions = transform.getDimensions();
 
         for (int i = 0; i < dimensions; i++) {
-            // ensure position does not fall below the lower bound
             if (position[i] < boundsMin[i]) {
                 position[i] = boundsMin[i];
             }
-            // ensure position + size does not exceed the upper bound
             if (position[i] + size[i] > boundsMax[i]) {
                 position[i] = boundsMax[i] - size[i];
             }
         }
 
-        // write the clamped values back
         transform.setPosition(position);
     }
 }

--- a/core/src/main/java/com/p1_7/abstractengine/render/ICustomRenderable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/ICustomRenderable.java
@@ -4,12 +4,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 
 /**
- * interface for entities that provide custom rendering logic.
- *
- * entities implementing this interface own their rendering behaviour, eliminating
- * instanceof checks in render managers. when rendercustom() is called, the shaperenderer
- * is active with filled mode and the spritebatch is inactive. implementations that need
- * to switch renderers must end/begin them correctly and restore the original state.
+ * interface for entities that provide their own rendering logic.
  */
 public interface ICustomRenderable {
 

--- a/core/src/main/java/com/p1_7/abstractengine/render/IRenderItem.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/IRenderItem.java
@@ -3,12 +3,7 @@ package com.p1_7.abstractengine.render;
 import com.p1_7.abstractengine.transform.ITransformable;
 
 /**
- * combines renderable and spatial contracts into a single interface
- * that the IRenderQueue and RenderManager operate on.
- *
- * no additional methods are declared; the interface exists to give
- * the render pipeline a single type to work with rather than
- * requiring casts.
+ * combines IRenderable and ITransformable into a single type for the render pipeline.
  */
 public interface IRenderItem extends IRenderable, ITransformable {
 }

--- a/core/src/main/java/com/p1_7/abstractengine/render/IRenderQueue.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/IRenderQueue.java
@@ -1,12 +1,7 @@
 package com.p1_7.abstractengine.render;
 
 /**
- * a single-frame accumulator for items that should be drawn this tick.
- *
- * scenes submit IRenderItem instances each frame via
- * queue(IRenderItem). the RenderManager consumes
- * the queue during the draw pass and then calls clear().
- * implementations are provided internally by the render manager.
+ * single-frame accumulator for render items submitted by scenes each tick.
  */
 public interface IRenderQueue {
 

--- a/core/src/main/java/com/p1_7/abstractengine/render/IRenderable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/IRenderable.java
@@ -2,11 +2,6 @@ package com.p1_7.abstractengine.render;
 
 /**
  * base capability interface for any object the render system can draw.
- *
- * if getAssetPath() returns null the entity is
- * drawn procedurally (e.g. as a filled rectangle via
- * ShapeRenderer). a non-null path indicates a textured
- * asset that should be loaded and drawn via a SpriteBatch.
  */
 public interface IRenderable {
 

--- a/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
@@ -10,21 +10,8 @@ import com.p1_7.abstractengine.engine.Manager;
 import com.p1_7.abstractengine.transform.ITransform;
 
 /**
- * owns the drawing resources and drives the per-frame render pass.
- *
- * this manager extends Manager directly - it has no
- * per-frame update() logic. all drawing happens inside the
- * explicit render() call that the com.p1_7.abstractengine.engine.Engine
- * issues each frame.
- *
- * the render pass is split into two phases:
- * 1. textured phase - items whose
- *    IRenderable.getAssetPath() is non-null are drawn via a
- *    SpriteBatch.
- * 2. procedural phase - items that return
- *    null from getAssetPath() are drawn as filled
- *    rectangles via a ShapeRenderer.
- * after both phases complete the queue is cleared.
+ * owns the drawing resources and drives the per-frame render pass for all
+ * queued items.
  */
 public class RenderManager extends Manager {
 
@@ -39,10 +26,6 @@ public class RenderManager extends Manager {
 
     /** single-frame queue of items to draw */
     private final RenderQueue queue = new RenderQueue();
-
-    // ---------------------------------------------------------------
-    // Manager lifecycle hooks
-    // ---------------------------------------------------------------
 
     /**
      * creates the SpriteBatch, ShapeRenderer, and
@@ -67,10 +50,6 @@ public class RenderManager extends Manager {
         if (shapeRenderer != null) { shapeRenderer.dispose(); }
     }
 
-    // ---------------------------------------------------------------
-    // public API
-    // ---------------------------------------------------------------
-
     /**
      * returns the render queue that scenes use to submit items for
      * drawing.
@@ -82,20 +61,11 @@ public class RenderManager extends Manager {
     }
 
     /**
-     * executes the full render pass for the current frame.
-     *
-     * 1. textured phase: iterates the queue and draws every item
-     *    that has a non-null asset path via the SpriteBatch.
-     * 2. procedural phase: iterates the queue and draws every item
-     *    that has a null asset path as a filled rectangle via the
-     *    ShapeRenderer.
-     * 3. clears the queue so it is empty for the next frame.
+     * executes the full render pass for the current frame, then clears the queue.
      */
     public void render() {
-        // ensure all queued assets are loaded
         assetManager.finishLoading();
 
-        // --- textured pass ---
         batch.begin();
         for (IRenderItem item : queue.items()) {
             if (item.getAssetPath() != null) {
@@ -104,7 +74,6 @@ public class RenderManager extends Manager {
         }
         batch.end();
 
-        // --- procedural pass ---
         shapeRenderer.begin(ShapeType.Filled);
         for (IRenderItem item : queue.items()) {
             if (item.getAssetPath() == null) {
@@ -113,33 +82,25 @@ public class RenderManager extends Manager {
         }
         shapeRenderer.end();
 
-        // --- flush ---
         queue.clear();
     }
 
-    // ---------------------------------------------------------------
-    // private drawing helpers
-    // ---------------------------------------------------------------
-
     /**
-     * draws a textured or text item. loads textures via AssetManager
-     * on first access and draws them with the SpriteBatch. handles
-     * special text rendering for LivesDisplay.
+     * draws a textured item using its asset path.
      *
-     * @param item the render item with a non-null asset path (or text item)
+     * @param item the render item with a non-null asset path
      */
     private void drawTextured(IRenderItem item) {
         String assetPath = item.getAssetPath();
 
-        // skip null paths (handled by procedural pass)
         if (assetPath == null) {
             return;
         }
 
-        // load texture via AssetManager if not already loaded
+        // blocking load on first access
         if (!assetManager.isLoaded(assetPath, Texture.class)) {
             assetManager.load(assetPath, Texture.class);
-            assetManager.finishLoadingAsset(assetPath);  // blocking load
+            assetManager.finishLoadingAsset(assetPath);
         }
 
         Texture texture = assetManager.get(assetPath, Texture.class);
@@ -151,10 +112,7 @@ public class RenderManager extends Manager {
     }
 
     /**
-     * hook for custom procedural rendering logic.
-     *
-     * checks if the item implements icustomrenderable and delegates to its rendercustom() method.
-     * subclasses can override to add additional custom rendering beyond icustomrenderable.
+     * hook for custom procedural rendering; delegates to ICustomRenderable if applicable.
      *
      * @param item the render item to potentially handle
      * @param batch the sprite batch (not currently active)
@@ -166,28 +124,22 @@ public class RenderManager extends Manager {
         SpriteBatch batch,
         ShapeRenderer shapeRenderer
     ) {
-        // check if item implements ICustomRenderable interface
         if (item instanceof ICustomRenderable) {
             ((ICustomRenderable) item).renderCustom(batch, shapeRenderer);
             return true;
         }
 
-        // not handled, fall back to default rectangle rendering
         return false;
     }
 
     /**
-     * draws a filled rectangle or delegates to custom rendering at the item's transform position.
-     * delegates to subclass hook for special rendering (e.g., text).
-     * falls back to rectangle drawing if not handled by subclass.
+     * draws the item procedurally, falling back to a filled rectangle.
      *
      * @param item the render item to draw procedurally
      */
     private void drawProcedural(IRenderItem item) {
-        // delegate to subclass hook for custom rendering
         boolean handled = renderCustomProcedural(item, batch, shapeRenderer);
 
-        // if not handled by custom logic, fall back to rectangle drawing
         if (!handled) {
             ITransform transform = item.getTransform();
             float[] position = transform.getPosition();

--- a/core/src/main/java/com/p1_7/abstractengine/render/RenderQueue.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/RenderQueue.java
@@ -3,12 +3,7 @@ package com.p1_7.abstractengine.render;
 import com.badlogic.gdx.utils.Array;
 
 /**
- * simple array-backed implementation of IRenderQueue.
- * one instance is held for the lifetime of the RenderManager.
- *
- * follows FIFO (first-in-first-out) ordering for rendering sequence:
- * items queued first are rendered first (back layers),
- * items queued last are rendered last (front layers).
+ * array-backed implementation of IRenderQueue.
  */
 class RenderQueue implements IRenderQueue {
 
@@ -34,8 +29,7 @@ class RenderQueue implements IRenderQueue {
     }
 
     /**
-     * returns the backing array so that the render manager can
-     * iterate it.
+     * returns the queued render items.
      *
      * @return the array of queued render items
      */

--- a/core/src/main/java/com/p1_7/abstractengine/scene/Scene.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/Scene.java
@@ -1,13 +1,8 @@
 package com.p1_7.abstractengine.scene;
 
 /**
- * abstract base class for every scene (game state) in the engine.
- *
- * concrete scenes override the lifecycle and per-frame hooks to
- * implement their own behaviour. a scene's update hook is
- * skipped when the scene is paused, but
- * submitRenderable(SceneContext) is always called so that
- * paused scenes can still render a static frame.
+ * abstract base class for every scene; update is skipped while paused but
+ * submitRenderable is always called.
  */
 public abstract class Scene {
 
@@ -16,10 +11,6 @@ public abstract class Scene {
 
     /** when true the per-frame update hook is skipped */
     protected boolean paused;
-
-    // ---------------------------------------------------------------
-    // lifecycle hooks — implemented by concrete scenes
-    // ---------------------------------------------------------------
 
     /**
      * called once when this scene becomes the active scene.
@@ -36,31 +27,19 @@ public abstract class Scene {
     public abstract void onExit(SceneContext context);
 
     /**
-     * called when this scene is being temporarily suspended (e.g., for pause menu).
-     * default implementation does nothing, preserving scene state.
-     *
-     * OPTIONAL: override ONLY if your scene needs custom suspend logic (e.g., pause audio).
-     * most scenes don't need to override this - the empty default is sufficient.
+     * called when this scene is temporarily suspended; default is a no-op.
      *
      * @param context the current engine context
      */
     public void onSuspend(SceneContext context) {
-        // default: preserve all state, do nothing
-        // scenes override ONLY if needed
     }
 
     /**
-     * called when this scene is being resumed after suspension.
-     * default implementation does nothing, assuming state was preserved.
-     *
-     * OPTIONAL: override ONLY if your scene needs to reconnect resources (e.g., resume audio).
-     * most scenes don't need to override this - the empty default is sufficient.
+     * called when this scene resumes after suspension; default is a no-op.
      *
      * @param context the current engine context
      */
     public void onResume(SceneContext context) {
-        // default: state already preserved, do nothing
-        // scenes override ONLY if needed
     }
 
     /**
@@ -78,10 +57,6 @@ public abstract class Scene {
      * @param context the current engine context
      */
     public abstract void submitRenderable(SceneContext context);
-
-    // ---------------------------------------------------------------
-    // concrete accessors
-    // ---------------------------------------------------------------
 
     /**
      * returns the name (key) of this scene.

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneContext.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneContext.java
@@ -5,12 +5,8 @@ import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.render.IRenderQueue;
 
 /**
- * snapshot of engine state passed into every Scene callback.
- *
- * a Scene receives a SceneContext so that it can query and mutate
- * entities, submit render items, read input, and request scene
- * transitions — without holding direct references to the underlying
- * managers.
+ * snapshot of engine state passed into every Scene callback, providing access
+ * to entities, render, input, and scene transitions.
  */
 public interface SceneContext {
 
@@ -37,22 +33,14 @@ public interface SceneContext {
     IInputQuery input();
 
     /**
-     * requests a deferred transition to the scene identified by key.
-     * the transition is resolved at the top of the next update tick.
+     * requests a transition to the scene identified by key.
      *
      * @param key the name of the target scene
      */
     void changeScene(String key);
 
     /**
-     * requests a deferred suspend transition to the scene identified by key.
-     * unlike changeScene(), this preserves the current scene's state by calling
-     * onSuspend() instead of onExit().
-     *
-     * use this for pause menus, settings overlays, or any transition where
-     * the current scene should resume exactly where it left off.
-     *
-     * the transition is resolved at the top of the next update tick.
+     * requests a deferred suspend transition, preserving the current scene's state.
      *
      * @param key the name of the target scene
      */
@@ -60,9 +48,6 @@ public interface SceneContext {
 
     /**
      * returns the scene registered under the specified key.
-     *
-     * useful for inter-scene communication, such as passing data
-     * to the target scene before transitioning.
      *
      * @param key the name of the scene to retrieve
      * @return the Scene, or null if not found

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
@@ -8,12 +8,8 @@ import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.render.IRenderQueue;
 
 /**
- * manages the collection of scenes and drives the active scene's
- * lifecycle and per-frame callbacks.
- *
- * scene transitions are deferred: requestChange(String)
- * stores the target key and the actual swap happens at the top of the
- * next update tick. this avoids mutating state mid-frame.
+ * manages the scene registry and drives the active scene's lifecycle and
+ * per-frame callbacks.
  */
 public class SceneManager extends UpdatableManager {
 
@@ -60,20 +56,11 @@ public class SceneManager extends UpdatableManager {
         this.inputQuery = inputQuery;
     }
 
-    // ---------------------------------------------------------------
-    // Manager lifecycle hooks
-    // ---------------------------------------------------------------
-
     /**
-     * assembles the SceneContext from the injected
-     * references. if an initial scene has already been set via
-     * setInitialScene(String), its Scene.onEnter
-     * callback is invoked immediately.
+     * assembles the SceneContext and enters the initial scene if one has been set.
      */
     @Override
     protected void onInit() {
-        // build context as an anonymous implementation that closes
-        // over the injected references
         context = new SceneContext() {
             @Override
             public IEntityManager entities() {
@@ -106,7 +93,6 @@ public class SceneManager extends UpdatableManager {
             }
         };
 
-        // if an initial scene was registered before init, enter it now
         if (currentKey != null && scenes.containsKey(currentKey)) {
             scenes.get(currentKey).onEnter(context);
         }
@@ -124,10 +110,6 @@ public class SceneManager extends UpdatableManager {
         scenes.clear();
     }
 
-    // ---------------------------------------------------------------
-    // scene registration & configuration
-    // ---------------------------------------------------------------
-
     /**
      * adds a scene to the registry, keyed by its name.
      *
@@ -138,9 +120,7 @@ public class SceneManager extends UpdatableManager {
     }
 
     /**
-     * sets the initial scene key. must be called before
-     * com.p1_7.abstractengine.engine.Engine.init() so that
-     * onInit() can enter the scene.
+     * sets the initial scene key; must be called before the engine is initialised.
      *
      * @param key the name of the scene to start in
      * @throws IllegalArgumentException if key is null or blank
@@ -156,9 +136,7 @@ public class SceneManager extends UpdatableManager {
     }
 
     /**
-     * requests a deferred transition to the scene identified by
-     * key. the transition is resolved at the top of the next
-     * update tick.
+     * schedules a transition to the named scene for the next update tick.
      *
      * @param key the name of the target scene
      */
@@ -168,9 +146,7 @@ public class SceneManager extends UpdatableManager {
     }
 
     /**
-     * requests a deferred suspend transition to the scene identified by
-     * key. the transition is resolved at the top of the next
-     * update tick using onSuspend/onResume instead of onExit/onEnter.
+     * schedules a suspend transition to the named scene for the next update tick.
      *
      * @param key the name of the target scene
      */
@@ -196,10 +172,6 @@ public class SceneManager extends UpdatableManager {
             throw new IllegalArgumentException("scene not registered: " + key);
         }
     }
-
-    // ---------------------------------------------------------------
-    // accessors
-    // ---------------------------------------------------------------
 
     /**
      * returns the currently active scene.
@@ -257,10 +229,6 @@ public class SceneManager extends UpdatableManager {
         this.suspendedSceneKey = null;
     }
 
-    // ---------------------------------------------------------------
-    // UpdatableManager hook
-    // ---------------------------------------------------------------
-
     /**
      * resolves any pending scene transition, then drives the active
      * scene's update and render-submission hooks.
@@ -269,44 +237,33 @@ public class SceneManager extends UpdatableManager {
      */
     @Override
     protected void onUpdate(float deltaTime) {
-        // 1a. resolve a pending suspend transition if one was requested
         if (pendingSuspendKey != null) {
-            // suspend the current scene (preserve state)
             if (currentKey != null && scenes.containsKey(currentKey)) {
                 scenes.get(currentKey).onSuspend(context);
             }
-            // swap to the new scene
             String previousKey = currentKey;
             currentKey = pendingSuspendKey;
             pendingSuspendKey = null;
-            // enter the new scene normally (it's starting fresh)
             if (scenes.containsKey(currentKey)) {
                 scenes.get(currentKey).onEnter(context);
             }
-            // store previous key for resume
             storePreviousScene(previousKey);
         }
 
-        // 1b. resolve a pending change transition if one was requested
         if (pendingKey != null) {
-            // check if we're returning to a suspended scene
             boolean isResuming = (pendingKey != null && pendingKey.equals(getSuspendedScene()));
 
             if (isResuming) {
-                // exit current scene normally
                 if (currentKey != null && scenes.containsKey(currentKey)) {
                     scenes.get(currentKey).onExit(context);
                 }
-                // swap to the suspended scene
                 currentKey = pendingKey;
                 pendingKey = null;
                 clearSuspendedScene();
-                // resume the suspended scene (preserve state)
                 if (scenes.containsKey(currentKey)) {
                     scenes.get(currentKey).onResume(context);
                 }
             } else {
-                // normal transition: exit current, enter new
                 if (currentKey != null && scenes.containsKey(currentKey)) {
                     scenes.get(currentKey).onExit(context);
                 }
@@ -323,12 +280,12 @@ public class SceneManager extends UpdatableManager {
             return;
         }
 
-        // 2. update — skipped while paused
+        // skipped while paused
         if (!current.isPaused()) {
             current.update(deltaTime, context);
         }
 
-        // 3. submit renderables — always called
+        // always called
         current.submitRenderable(context);
     }
 }

--- a/core/src/main/java/com/p1_7/abstractengine/transform/ITransform.java
+++ b/core/src/main/java/com/p1_7/abstractengine/transform/ITransform.java
@@ -2,12 +2,6 @@ package com.p1_7.abstractengine.transform;
 
 /**
  * dimension-agnostic spatial state for an entity.
- *
- * all positional and size data is expressed as plain float[]
- * arrays. the length of each array is determined by the concrete
- * implementation; the abstract engine does not assume any particular
- * dimensionality. demo code that targets 2-D will use arrays of
- * length 2.
  */
 public interface ITransform {
 
@@ -41,8 +35,6 @@ public interface ITransform {
 
     /**
      * returns the number of spatial dimensions this transform operates in.
-     * concrete implementations decide the value; demo code will typically
-     * return 2.
      *
      * @return the dimensionality (length of the position and size arrays)
      */

--- a/core/src/main/java/com/p1_7/abstractengine/transform/ITransformable.java
+++ b/core/src/main/java/com/p1_7/abstractengine/transform/ITransformable.java
@@ -1,12 +1,7 @@
 package com.p1_7.abstractengine.transform;
 
 /**
- * marker contract for any object that carries spatial state via an
- * ITransform.
- *
- * managers such as MovementManager cast registered objects
- * to this interface when they need to read or write position and size
- * data.
+ * marker contract for any object that exposes spatial state via an ITransform.
  */
 public interface ITransformable {
 


### PR DESCRIPTION
## Summary

- Trimmed class/interface Javadoc to 1–3 lines stating single responsibility across all 34 files in the abstractengine package
- Reduced method docs to one summary line with @param/@return/@throws tags only where non-obvious
- Removed over-documentation: O(n²) complexity notes, strategy enumerations, pipeline descriptions, "demo phase" references, and concrete implementation examples from interface docs
- Removed all section-separator banners and self-evident inline comments
- Removed game-layer class references (`LivesDisplay`, `Settings`) from the abstract layer