### PR TITLE
feat: resolve manager init order automatically via topological sort

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
@@ -1,11 +1,14 @@
 package com.p1_7.abstractengine.engine;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.p1_7.abstractengine.render.RenderManager;
 
 /**
  * central orchestrator that manages manager lifecycles, drives the update loop,
- * and delegates the per-frame render call.
+ * and delegates the per-frame render call. managers are registered in any order
+ * and the engine resolves the correct initialisation sequence via a topological
+ * sort of declared dependencies.
  */
 public class Engine {
 
@@ -15,20 +18,102 @@ public class Engine {
     /** subset of managers (or standalone updatables) that update each frame */
     private final Array<IUpdatable> updatables = new Array<>();
 
+    /** type-keyed index of registered managers for dependency lookup */
+    private final ObjectMap<Class<? extends IManager>, IManager> managerMap = new ObjectMap<>();
+
     /** the render manager used for the explicit render step */
     private RenderManager renderManager;
 
+    /** guards against post-init registration */
+    private boolean initialised;
+
     /**
-     * registers a manager. if the manager also implements
-     * IUpdatable it is automatically added to the update loop.
+     * registers a manager and indexes it by type for dependency lookup.
      *
      * @param manager the manager to register
+     * @throws IllegalArgumentException if manager is null
+     * @throws IllegalStateException    if called after init()
+     * @throws IllegalStateException    if a type key already maps to a different manager
      */
     public void registerManager(IManager manager) {
+        if (manager == null) {
+            throw new IllegalArgumentException("manager cannot be null");
+        }
+        if (initialised) {
+            throw new IllegalStateException(
+                "cannot register managers after init() has been called");
+        }
+
         managers.add(manager);
         if (manager instanceof IUpdatable) {
             updatables.add((IUpdatable) manager);
         }
+
+        // index by concrete class and superclass chain
+        indexSuperclasses(manager);
+
+        // index by IManager-extending interfaces
+        indexInterfaces(manager);
+    }
+
+    /**
+     * indexes the concrete class and superclasses up to the framework bases.
+     *
+     * @param manager the manager to index
+     */
+    private void indexSuperclasses(IManager manager) {
+        Class<?> cls = manager.getClass();
+        while (cls != null
+               && cls != Manager.class
+               && cls != UpdatableManager.class
+               && cls != Object.class) {
+            if (IManager.class.isAssignableFrom(cls)) {
+                @SuppressWarnings("unchecked")
+                Class<? extends IManager> key = (Class<? extends IManager>) cls;
+                putMapping(key, manager);
+            }
+            cls = cls.getSuperclass();
+        }
+    }
+
+    /**
+     * indexes IManager-extending interfaces (excluding IManager itself).
+     *
+     * @param manager the manager to index
+     */
+    private void indexInterfaces(IManager manager) {
+        Class<?> cls = manager.getClass();
+        while (cls != null && cls != Object.class) {
+            for (Class<?> iface : cls.getInterfaces()) {
+                if (iface == IManager.class || iface == IUpdatable.class) {
+                    continue;
+                }
+                if (IManager.class.isAssignableFrom(iface)) {
+                    @SuppressWarnings("unchecked")
+                    Class<? extends IManager> key = (Class<? extends IManager>) iface;
+                    putMapping(key, manager);
+                }
+            }
+            cls = cls.getSuperclass();
+        }
+    }
+
+    /**
+     * inserts a type mapping; throws on duplicate keys.
+     *
+     * @param key     the type key
+     * @param manager the manager instance
+     * @throws IllegalStateException if the key already maps to a different instance
+     */
+    private void putMapping(Class<? extends IManager> key, IManager manager) {
+        IManager existing = managerMap.get(key);
+        if (existing != null && existing != manager) {
+            throw new IllegalStateException(
+                "duplicate manager mapping for " + key.getSimpleName()
+                + ": " + existing.getClass().getSimpleName()
+                + " and " + manager.getClass().getSimpleName());
+        }
+        managerMap.put(key, manager);
     }
 
     /**
@@ -41,25 +126,168 @@ public class Engine {
     }
 
     /**
-     * stores the render manager for the explicit per-frame render step.
+     * returns the manager registered under the given type key.
      *
-     * @param renderManager the render manager instance
-     * @throws IllegalArgumentException if renderManager is null
+     * @param <T>  the manager type
+     * @param type the class or interface key
+     * @return the matching manager instance
+     * @throws IllegalArgumentException if no manager is registered for the type
      */
-    public void setRenderManager(RenderManager renderManager) {
-        if (renderManager == null) {
-            throw new IllegalArgumentException("renderManager cannot be null");
+    @SuppressWarnings("unchecked")
+    public <T extends IManager> T getManager(Class<T> type) {
+        IManager manager = managerMap.get(type);
+        if (manager == null) {
+            throw new IllegalArgumentException(
+                "no manager registered for " + type.getSimpleName());
         }
-        this.renderManager = renderManager;
+        return (T) manager;
     }
 
     /**
-     * initialises every registered manager in registration order.
+     * sorts managers by dependency order, wires them, and initialises each one.
+     *
+     * @throws IllegalArgumentException if a dependency type is not registered
+     * @throws IllegalStateException    if a circular dependency is detected
+     * @throws IllegalStateException    if more than one RenderManager is found
      */
     public void init() {
+        // build sorted order from dependency graph
+        Array<IManager> sorted = topologicalSort();
+
+        // reorder managers list to sorted result
+        managers.clear();
+        managers.addAll(sorted);
+
+        // rebuild updatables preserving sorted relative order
+        updatables.clear();
+        for (int i = 0; i < managers.size; i++) {
+            IManager m = managers.get(i);
+            if (m instanceof IUpdatable) {
+                updatables.add((IUpdatable) m);
+            }
+        }
+
+        // auto-detect render manager
+        renderManager = null;
+        for (int i = 0; i < managers.size; i++) {
+            if (managers.get(i) instanceof RenderManager) {
+                if (renderManager != null) {
+                    throw new IllegalStateException(
+                        "multiple RenderManager instances registered");
+                }
+                renderManager = (RenderManager) managers.get(i);
+            }
+        }
+
+        // wiring pass — resolve and store dependency references
+        ManagerResolver resolver = new ManagerResolver() {
+            @Override
+            public <T extends IManager> T resolve(Class<T> type) {
+                return getManager(type);
+            }
+        };
+        for (int i = 0; i < managers.size; i++) {
+            IManager m = managers.get(i);
+            if (m instanceof Manager) {
+                ((Manager) m).onWire(resolver);
+            }
+        }
+
+        initialised = true;
+
+        // initialise in sorted order
         for (int i = 0; i < managers.size; i++) {
             managers.get(i).init();
         }
+    }
+
+    /**
+     * topologically sorts managers using kahn's algorithm. managers with no
+     * dependency relationship retain their original registration order.
+     *
+     * @return managers in dependency-resolved order
+     * @throws IllegalArgumentException if a dependency type is not registered
+     * @throws IllegalStateException    if a circular dependency is detected
+     */
+    private Array<IManager> topologicalSort() {
+        int n = managers.size;
+
+        // map each manager to its index for fast lookup
+        ObjectMap<IManager, Integer> indexOf = new ObjectMap<>(n);
+        for (int i = 0; i < n; i++) {
+            indexOf.put(managers.get(i), i);
+        }
+
+        // build adjacency list and in-degree count
+        // edge: dependency -> dependant (dependency must come first)
+        @SuppressWarnings("unchecked")
+        Array<Integer>[] adjacency = new Array[n];
+        int[] inDegree = new int[n];
+        for (int i = 0; i < n; i++) {
+            adjacency[i] = new Array<>();
+        }
+
+        for (int i = 0; i < n; i++) {
+            IManager m = managers.get(i);
+            if (!(m instanceof Manager)) {
+                continue;
+            }
+            Class<? extends IManager>[] deps = ((Manager) m).getDependencies();
+            for (Class<? extends IManager> depType : deps) {
+                IManager depManager = managerMap.get(depType);
+                if (depManager == null) {
+                    throw new IllegalArgumentException(
+                        m.getClass().getSimpleName()
+                        + " depends on " + depType.getSimpleName()
+                        + " but no such manager is registered");
+                }
+                Integer depIndex = indexOf.get(depManager);
+                // edge from dependency to dependant
+                adjacency[depIndex].add(i);
+                inDegree[i]++;
+            }
+        }
+
+        // seed queue with zero-in-degree nodes in registration order (fifo for stability)
+        Array<Integer> queue = new Array<>();
+        int head = 0;
+        for (int i = 0; i < n; i++) {
+            if (inDegree[i] == 0) {
+                queue.add(i);
+            }
+        }
+
+        Array<IManager> sorted = new Array<>(n);
+        while (head < queue.size) {
+            int current = queue.get(head++);
+            sorted.add(managers.get(current));
+
+            for (int j = 0; j < adjacency[current].size; j++) {
+                int neighbour = adjacency[current].get(j);
+                inDegree[neighbour]--;
+                if (inDegree[neighbour] == 0) {
+                    queue.add(neighbour);
+                }
+            }
+        }
+
+        if (sorted.size != n) {
+            // identify managers involved in the cycle
+            StringBuilder cycleInfo = new StringBuilder("circular dependency detected among: ");
+            boolean first = true;
+            for (int i = 0; i < n; i++) {
+                if (inDegree[i] > 0) {
+                    if (!first) {
+                        cycleInfo.append(", ");
+                    }
+                    cycleInfo.append(managers.get(i).getClass().getSimpleName());
+                    first = false;
+                }
+            }
+            throw new IllegalStateException(cycleInfo.toString());
+        }
+
+        return sorted;
     }
 
     /**
@@ -84,8 +312,8 @@ public class Engine {
     }
 
     /**
-     * shuts down every registered manager in reverse registration
-     * order so that dependants are torn down before their dependencies.
+     * shuts down every registered manager in reverse dependency order
+     * so that dependants are torn down before their dependencies.
      */
     public void shutdown() {
         for (int i = managers.size - 1; i >= 0; i--) {

--- a/core/src/main/java/com/p1_7/abstractengine/engine/Manager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/Manager.java
@@ -49,4 +49,24 @@ public abstract class Manager implements IManager {
     public boolean isInitialised() {
         return initialised;
     }
+
+    /**
+     * returns the direct dependencies of this manager; default is empty.
+     *
+     * @return an array of manager types this manager depends on
+     */
+    @SuppressWarnings("unchecked")
+    public Class<? extends IManager>[] getDependencies() {
+        return new Class[0];
+    }
+
+    /**
+     * wiring hook called before init(); override to resolve and store
+     * dependency references. default is a no-op.
+     *
+     * @param resolver the resolver used to look up dependency instances
+     */
+    public void onWire(ManagerResolver resolver) {
+        // no-op — subclasses may override
+    }
 }

--- a/core/src/main/java/com/p1_7/abstractengine/engine/ManagerResolver.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/ManagerResolver.java
@@ -1,0 +1,18 @@
+package com.p1_7.abstractengine.engine;
+
+/**
+ * lookup contract for resolving manager dependencies by type.
+ */
+@FunctionalInterface
+public interface ManagerResolver {
+
+    /**
+     * resolves a manager instance by its registered type.
+     *
+     * @param <T>  the manager type to resolve
+     * @param type the class or interface key to look up
+     * @return the matching manager instance
+     * @throws IllegalArgumentException if no manager is registered for the given type
+     */
+    <T extends IManager> T resolve(Class<T> type);
+}

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
@@ -2,10 +2,15 @@ package com.p1_7.abstractengine.scene;
 
 import com.badlogic.gdx.utils.ObjectMap;
 
+import com.p1_7.abstractengine.engine.IManager;
+import com.p1_7.abstractengine.engine.ManagerResolver;
 import com.p1_7.abstractengine.engine.UpdatableManager;
+import com.p1_7.abstractengine.entity.EntityManager;
 import com.p1_7.abstractengine.entity.IEntityManager;
 import com.p1_7.abstractengine.input.IInputQuery;
+import com.p1_7.abstractengine.input.InputManager;
 import com.p1_7.abstractengine.render.IRenderQueue;
+import com.p1_7.abstractengine.render.RenderManager;
 
 /**
  * manages the scene registry and drives the active scene's lifecycle and
@@ -31,29 +36,38 @@ public class SceneManager extends UpdatableManager {
     /** the context object passed into scene callbacks */
     private SceneContext context;
 
-    /** injected entity manager — used to build the context */
-    private final IEntityManager entityManager;
+    /** entity manager — resolved during wiring */
+    private IEntityManager entityManager;
 
-    /** injected render queue — used to build the context */
-    private final IRenderQueue renderQueue;
+    /** render queue — resolved during wiring */
+    private IRenderQueue renderQueue;
 
-    /** injected input query — used to build the context */
-    private final IInputQuery inputQuery;
+    /** input query — resolved during wiring */
+    private IInputQuery inputQuery;
 
     /**
-     * constructs a SceneManager with the dependencies it needs to
-     * assemble a SceneContext.
-     *
-     * @param entityManager the entity manager providing read and write access
-     * @param renderQueue   the single-frame render queue
-     * @param inputQuery    the input query interface
+     * {@inheritDoc}
      */
-    public SceneManager(IEntityManager entityManager,
-                        IRenderQueue renderQueue,
-                        IInputQuery inputQuery) {
-        this.entityManager = entityManager;
-        this.renderQueue = renderQueue;
-        this.inputQuery = inputQuery;
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends IManager>[] getDependencies() {
+        return new Class[] {
+            EntityManager.class,
+            RenderManager.class,
+            InputManager.class
+        };
+    }
+
+    /**
+     * resolves and stores the entity manager, render queue, and input query.
+     *
+     * @param resolver the resolver used to look up dependency instances
+     */
+    @Override
+    public void onWire(ManagerResolver resolver) {
+        entityManager = resolver.resolve(EntityManager.class);
+        renderQueue = resolver.resolve(RenderManager.class).getRenderQueue();
+        inputQuery = resolver.resolve(InputManager.class);
     }
 
     /**

--- a/core/src/main/java/com/p1_7/demo/Main.java
+++ b/core/src/main/java/com/p1_7/demo/Main.java
@@ -39,7 +39,7 @@ public class Main extends ApplicationAdapter {
         collisionManager = new DemoCollisionManager();
         inputManager = new InputManager();
         renderManager = new RenderManager();
-        sceneManager = new SceneManager(entityManager, renderManager.getRenderQueue(), inputManager);
+        sceneManager = new SceneManager();
 
         float[] worldMinBound = { 0f, 0f };
         float[] worldMaxBound = { Settings.WINDOW_WIDTH, Settings.WINDOW_HEIGHT };
@@ -68,7 +68,7 @@ public class Main extends ApplicationAdapter {
         // set menu as initial scene
         sceneManager.setInitialScene("menu");
 
-        // 6. register managers with engine (documented order)
+        // 6. register managers with engine (order is irrelevant; dependencies are wired automatically)
         engine.registerManager(entityManager);
         engine.registerManager(movementManager);
         engine.registerManager(collisionManager);
@@ -76,10 +76,7 @@ public class Main extends ApplicationAdapter {
         engine.registerManager(renderManager);
         engine.registerManager(sceneManager);
 
-        // 7. set render manager for explicit render call
-        engine.setRenderManager(renderManager);
-
-        // 8. initialise engine
+        // 7. initialise engine
         engine.init();
     }
 


### PR DESCRIPTION
Replace manual registration ordering and constructor-injected dependencies with a dependency graph approach. Managers now declare dependencies via getDependencies() and receive wired references through onWire() before init(). Engine builds a topological sort using Kahn's algorithm, auto-detects the RenderManager, and guards against post-init registration and circular dependencies.