### PR TITLE
refactor: replace array-returning ITransform accessors with per-axis indexed methods

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/movement/MovementManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/movement/MovementManager.java
@@ -112,19 +112,20 @@ public class MovementManager extends UpdatableManager {
      */
     private void clampToBounds(ITransformable transformable) {
         ITransform transform = transformable.getTransform();
-        float[] position = transform.getPosition();
-        float[] size = transform.getSize();
         int dimensions = transform.getDimensions();
 
         for (int i = 0; i < dimensions; i++) {
-            if (position[i] < boundsMin[i]) {
-                position[i] = boundsMin[i];
-            }
-            if (position[i] + size[i] > boundsMax[i]) {
-                position[i] = boundsMax[i] - size[i];
-            }
-        }
+            float pos = transform.getPosition(i);
+            float size = transform.getSize(i);
 
-        transform.setPosition(position);
+            if (pos < boundsMin[i]) {
+                pos = boundsMin[i];
+            }
+            if (pos + size > boundsMax[i]) {
+                pos = boundsMax[i] - size;
+            }
+
+            transform.setPosition(i, pos);
+        }
     }
 }

--- a/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
@@ -116,9 +116,9 @@ public abstract class RenderManager extends Manager {
         Object textureHandle = assetStore.loadTexture(assetPath);
 
         ITransform transform = item.getTransform();
-        float[] position = transform.getPosition();
-        float[] size = transform.getSize();
 
-        batch.draw(textureHandle, position[0], position[1], size[0], size[1]);
+        batch.draw(textureHandle,
+            transform.getPosition(0), transform.getPosition(1),
+            transform.getSize(0), transform.getSize(1));
     }
 }

--- a/core/src/main/java/com/p1_7/abstractengine/transform/ITransform.java
+++ b/core/src/main/java/com/p1_7/abstractengine/transform/ITransform.java
@@ -2,41 +2,48 @@ package com.p1_7.abstractengine.transform;
 
 /**
  * dimension-agnostic spatial state for an entity.
+ *
+ * uses per-axis indexed accessors to prevent external mutation of
+ * internal state through leaked array references.
  */
 public interface ITransform {
 
     /**
-     * returns the current position as a float array.
+     * returns the position component for the given axis.
      *
-     * @return the position vector; length equals the number of dimensions
+     * @param axis the axis index (e.g. 0 for x, 1 for y)
+     * @return the position value along that axis
      */
-    float[] getPosition();
+    float getPosition(int axis);
 
     /**
-     * sets the position to the supplied values.
+     * sets the position component for the given axis.
      *
-     * @param position the new position vector
+     * @param axis  the axis index (e.g. 0 for x, 1 for y)
+     * @param value the new position value along that axis
      */
-    void setPosition(float[] position);
+    void setPosition(int axis, float value);
 
     /**
-     * returns the current size (extent in each dimension) as a float array.
+     * returns the size component for the given axis.
      *
-     * @return the size vector; length equals the number of dimensions
+     * @param axis the axis index (e.g. 0 for width, 1 for height)
+     * @return the size value along that axis
      */
-    float[] getSize();
+    float getSize(int axis);
 
     /**
-     * sets the size to the supplied values.
+     * sets the size component for the given axis.
      *
-     * @param size the new size vector
+     * @param axis  the axis index (e.g. 0 for width, 1 for height)
+     * @param value the new size value along that axis
      */
-    void setSize(float[] size);
+    void setSize(int axis, float value);
 
     /**
      * returns the number of spatial dimensions this transform operates in.
      *
-     * @return the dimensionality (length of the position and size arrays)
+     * @return the dimensionality
      */
     int getDimensions();
 }

--- a/core/src/main/java/com/p1_7/demo/core/SpriteEntity.java
+++ b/core/src/main/java/com/p1_7/demo/core/SpriteEntity.java
@@ -86,9 +86,8 @@ public abstract class SpriteEntity extends Entity implements IRenderItem, IMovab
         velocity[0] += acceleration[0] * deltaTime;
         velocity[1] += acceleration[1] * deltaTime;
 
-        float[] position = transform.getPosition();
-        position[0] += velocity[0] * deltaTime;
-        position[1] += velocity[1] * deltaTime;
+        transform.setPosition(0, transform.getPosition(0) + velocity[0] * deltaTime);
+        transform.setPosition(1, transform.getPosition(1) + velocity[1] * deltaTime);
     }
 
     // ==================== ICollidable ====================
@@ -96,9 +95,9 @@ public abstract class SpriteEntity extends Entity implements IRenderItem, IMovab
     @Override
     public IBounds getBounds() {
         // derive bounding box from transform (sync cached rectangle)
-        float[] position = transform.getPosition();
-        float[] size = transform.getSize();
-        bounds.set(position[0], position[1], size[0], size[1]);
+        bounds.set(
+            transform.getPosition(0), transform.getPosition(1),
+            transform.getSize(0), transform.getSize(1));
         return bounds;
     }
 

--- a/core/src/main/java/com/p1_7/demo/core/Transform2D.java
+++ b/core/src/main/java/com/p1_7/demo/core/Transform2D.java
@@ -6,7 +6,7 @@ import com.p1_7.abstractengine.transform.ITransform;
  * concrete 2D implementation of ITransform.
  *
  * manages position (x, y) and size (width, height) in 2D space.
- * arrays are copied on set operations to prevent external mutation.
+ * per-axis indexed accessors prevent external mutation of internal arrays.
  */
 public class Transform2D implements ITransform {
 
@@ -32,25 +32,23 @@ public class Transform2D implements ITransform {
     }
 
     @Override
-    public float[] getPosition() {
-        return position;
+    public float getPosition(int axis) {
+        return position[axis];
     }
 
     @Override
-    public void setPosition(float[] position) {
-        // use System.arraycopy to prevent external mutation
-        System.arraycopy(position, 0, this.position, 0, 2);
+    public void setPosition(int axis, float value) {
+        position[axis] = value;
     }
 
     @Override
-    public float[] getSize() {
-        return size;
+    public float getSize(int axis) {
+        return size[axis];
     }
 
     @Override
-    public void setSize(float[] size) {
-        // use System.arraycopy to prevent external mutation
-        System.arraycopy(size, 0, this.size, 0, 2);
+    public void setSize(int axis, float value) {
+        size[axis] = value;
     }
 
     @Override

--- a/core/src/main/java/com/p1_7/demo/display/BaseTextDisplay.java
+++ b/core/src/main/java/com/p1_7/demo/display/BaseTextDisplay.java
@@ -55,8 +55,8 @@ public abstract class BaseTextDisplay extends Entity implements IRenderItem, ICu
         ((GdxSpriteBatch) batch).unwrap().begin();
 
         // render the text at the transform position
-        float[] position = transform.getPosition();
-        font.draw(((GdxSpriteBatch) batch).unwrap(), getText(), position[0], position[1]);
+        font.draw(((GdxSpriteBatch) batch).unwrap(), getText(),
+            transform.getPosition(0), transform.getPosition(1));
 
         // restore shaperenderer for subsequent procedural items
         ((GdxSpriteBatch) batch).unwrap().end();

--- a/core/src/main/java/com/p1_7/demo/display/VolumeSlider.java
+++ b/core/src/main/java/com/p1_7/demo/display/VolumeSlider.java
@@ -105,9 +105,8 @@ public class VolumeSlider extends Entity implements IRenderItem, ICustomRenderab
     @Override
     public void renderCustom(ISpriteBatch batch, IShapeRenderer shapeRenderer) {
         ShapeRenderer sr = ((GdxShapeRenderer) shapeRenderer).unwrap();
-        float[] position = transform.getPosition();
-        float x = position[0];
-        float y = position[1];
+        float x = transform.getPosition(0);
+        float y = transform.getPosition(1);
 
         // draw background bar (grey)
         sr.setColor(0.3f, 0.3f, 0.3f, 1f);

--- a/core/src/main/java/com/p1_7/demo/entities/Cloud.java
+++ b/core/src/main/java/com/p1_7/demo/entities/Cloud.java
@@ -51,14 +51,15 @@ public class Cloud extends SpriteEntity {
     @Override
     public IBounds getBounds() {
         // create collision box that matches visible cloud body (not full sprite)
-        float[] position = transform.getPosition();
+        float cloudX = transform.getPosition(0);
+        float cloudY = transform.getPosition(1);
 
         // move box down to skip transparent top pixels
-        float collisionY = position[1] + COLLISION_OFFSET_Y;
+        float collisionY = cloudY + COLLISION_OFFSET_Y;
 
         // use full width but reduced height
         collisionBounds.set(
-            position[0],           // x: same as sprite
+            cloudX,                // x: same as sprite
             collisionY,            // y: offset down
             COLLISION_WIDTH,
             COLLISION_HEIGHT       // height: reduced (50 instead of 81)
@@ -73,14 +74,15 @@ public class Cloud extends SpriteEntity {
             Droplet droplet = (Droplet) other;
 
             // get cloud collision box position
-            float[] cloudPos = transform.getPosition();
-            float collisionY = cloudPos[1] + COLLISION_OFFSET_Y;
+            float cloudX = transform.getPosition(0);
+            float cloudY = transform.getPosition(1);
+            float collisionY = cloudY + COLLISION_OFFSET_Y;
             float collisionCentreY = collisionY + (COLLISION_HEIGHT / 2f);
 
             // get droplet position and centre
-            float[] dropletPos = droplet.getTransform().getPosition();
-            float dropletCentreY = dropletPos[1] + (Droplet.DROPLET_HEIGHT / 2f);
-            float dropletX = dropletPos[0];
+            float dropletX = droplet.getTransform().getPosition(0);
+            float dropletY = droplet.getTransform().getPosition(1);
+            float dropletCentreY = dropletY + (Droplet.DROPLET_HEIGHT / 2f);
 
             // check if droplet is hitting from above (not from side)
             // compare vertical centres: if droplet centre is above cloud centre, it's a top hit
@@ -92,7 +94,7 @@ public class Cloud extends SpriteEntity {
                 float[] velocity = droplet.getVelocity();
 
                 // get cloud centre for push direction
-                float cloudCentreX = cloudPos[0] + (CLOUD_WIDTH / 2f);
+                float cloudCentreX = cloudX + (CLOUD_WIDTH / 2f);
 
                 // push horizontally while allowing slow downward movement
                 // this lets droplets slide across and eventually fall out of collision box

--- a/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
@@ -10,6 +10,7 @@ import com.p1_7.abstractengine.collision.CollisionManager;
 import com.p1_7.abstractengine.entity.IEntityMutator;
 import com.p1_7.abstractengine.movement.MovementManager;
 import com.p1_7.abstractengine.scene.Scene;
+import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.demo.Settings;
 import com.p1_7.demo.display.LivesDisplay;
@@ -255,13 +256,13 @@ public class GameScene extends Scene {
             droplet.setVelocity(velocity);
 
             // clamp droplet to horizontal bounds (prevent sliding off-screen)
-            float[] position = droplet.getTransform().getPosition();
-            if (position[0] < 0) {
-                position[0] = 0;
-            } else if (position[0] + Droplet.DROPLET_WIDTH > Settings.WINDOW_WIDTH) {
-                position[0] = Settings.WINDOW_WIDTH - Droplet.DROPLET_WIDTH;
+            ITransform dropletTransform = droplet.getTransform();
+            float dropletX = dropletTransform.getPosition(0);
+            if (dropletX < 0) {
+                dropletTransform.setPosition(0, 0);
+            } else if (dropletX + Droplet.DROPLET_WIDTH > Settings.WINDOW_WIDTH) {
+                dropletTransform.setPosition(0, Settings.WINDOW_WIDTH - Droplet.DROPLET_WIDTH);
             }
-            droplet.getTransform().setPosition(position);
 
             // check if caught
             if (droplet.isCaught()) {
@@ -277,7 +278,7 @@ public class GameScene extends Scene {
             }
 
             // check if missed (fell below screen)
-            if (droplet.getTransform().getPosition()[1] < 0) {
+            if (droplet.getTransform().getPosition(1) < 0) {
                 // decrement lives
                 int currentLives = livesDisplay.getLives();
                 livesDisplay.setLives(currentLives - 1);


### PR DESCRIPTION
Eliminates encapsulation leak where getters returned mutable float[] references, allowing external code to silently mutate internal state. Also fixes latent bug in SpriteEntity.move() that mutated returned array without calling setPosition().