### PR TITLE
refactor: extract DAG data structure and dependency sorter from Engine

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/engine/DependencySorter.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/DependencySorter.java
@@ -1,0 +1,137 @@
+package com.p1_7.abstractengine.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * sorts managers into dependency-resolved initialisation order using kahn's
+ * algorithm over a directed acyclic graph built from each manager's declared
+ * dependencies.
+ */
+public class DependencySorter {
+
+    /**
+     * builds a dependency graph from the given managers and returns them in
+     * topologically sorted order. managers with no dependency relationship
+     * retain their original registration order.
+     *
+     * @param managers   the managers to sort, in registration order
+     * @param managerMap type-keyed index used to resolve dependency types
+     * @return managers in dependency-resolved order
+     * @throws IllegalArgumentException if a dependency type is not registered
+     * @throws IllegalStateException    if a circular dependency is detected
+     */
+    public List<IManager> sort(
+            List<IManager> managers,
+            Map<Class<? extends IManager>, IManager> managerMap) {
+
+        // build the dependency graph
+        DirectedAcyclicGraph<IManager> graph = buildGraph(managers, managerMap);
+
+        // run kahn's algorithm
+        return kahnSort(graph);
+    }
+
+    /**
+     * constructs a dag where an edge from a to b means a must be initialised
+     * before b.
+     *
+     * @param managers   the managers to add as nodes
+     * @param managerMap type-keyed index for resolving dependency types
+     * @return the populated directed acyclic graph
+     */
+    private DirectedAcyclicGraph<IManager> buildGraph(
+            List<IManager> managers,
+            Map<Class<? extends IManager>, IManager> managerMap) {
+
+        DirectedAcyclicGraph<IManager> graph = new DirectedAcyclicGraph<>();
+
+        // register every manager as a node
+        for (int i = 0; i < managers.size(); i++) {
+            graph.addNode(managers.get(i));
+        }
+
+        // add edges from each dependency to the dependant
+        for (int i = 0; i < managers.size(); i++) {
+            IManager manager = managers.get(i);
+            if (!(manager instanceof Manager)) {
+                continue;
+            }
+            Class<? extends IManager>[] deps = ((Manager) manager).getDependencies();
+            for (Class<? extends IManager> depType : deps) {
+                IManager depManager = managerMap.get(depType);
+                if (depManager == null) {
+                    throw new IllegalArgumentException(
+                        manager.getClass().getSimpleName()
+                        + " depends on " + depType.getSimpleName()
+                        + " but no such manager is registered");
+                }
+                // dependency must come before dependant
+                graph.addEdge(depManager, manager);
+            }
+        }
+
+        return graph;
+    }
+
+    /**
+     * runs kahn's algorithm on the graph, returning nodes in topological order.
+     *
+     * @param graph the directed acyclic graph to sort
+     * @return sorted node list
+     * @throws IllegalStateException if the graph contains a cycle
+     */
+    private List<IManager> kahnSort(DirectedAcyclicGraph<IManager> graph) {
+        List<IManager> nodes = graph.getNodes();
+        int n = graph.size();
+
+        // track mutable in-degrees without modifying the graph
+        int[] inDegree = new int[n];
+        for (int i = 0; i < n; i++) {
+            inDegree[i] = graph.getInDegree(nodes.get(i));
+        }
+
+        // seed queue with zero-in-degree nodes in registration order (fifo for stability)
+        List<Integer> queue = new ArrayList<>();
+        int head = 0;
+        for (int i = 0; i < n; i++) {
+            if (inDegree[i] == 0) {
+                queue.add(i);
+            }
+        }
+
+        List<IManager> sorted = new ArrayList<>(n);
+        while (head < queue.size()) {
+            int current = queue.get(head++);
+            sorted.add(nodes.get(current));
+
+            List<IManager> neighbours = graph.getNeighbours(nodes.get(current));
+            for (int j = 0; j < neighbours.size(); j++) {
+                int neighbourIdx = nodes.indexOf(neighbours.get(j));
+                inDegree[neighbourIdx]--;
+                if (inDegree[neighbourIdx] == 0) {
+                    queue.add(neighbourIdx);
+                }
+            }
+        }
+
+        if (sorted.size() != n) {
+            // identify managers involved in the cycle
+            StringBuilder cycleInfo = new StringBuilder("circular dependency detected among: ");
+            boolean first = true;
+            for (int i = 0; i < n; i++) {
+                if (inDegree[i] > 0) {
+                    if (!first) {
+                        cycleInfo.append(", ");
+                    }
+                    cycleInfo.append(nodes.get(i).getClass().getSimpleName());
+                    first = false;
+                }
+            }
+            throw new IllegalStateException(cycleInfo.toString());
+        }
+
+        return sorted;
+    }
+}

--- a/core/src/main/java/com/p1_7/abstractengine/engine/DirectedAcyclicGraph.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/DirectedAcyclicGraph.java
@@ -1,0 +1,85 @@
+package com.p1_7.abstractengine.engine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * generic directed acyclic graph backed by an adjacency list and in-degree map.
+ * nodes are stored in insertion order.
+ *
+ * @param <T> the node type
+ */
+public class DirectedAcyclicGraph<T> {
+
+    /** nodes in insertion order */
+    private final List<T> nodes = new ArrayList<>();
+
+    /** outgoing edges for each node */
+    private final Map<T, List<T>> adjacency = new HashMap<>();
+
+    /** number of incoming edges per node */
+    private final Map<T, Integer> inDegree = new HashMap<>();
+
+    /**
+     * registers a node in the graph.
+     *
+     * @param node the node to add
+     */
+    public void addNode(T node) {
+        nodes.add(node);
+        adjacency.put(node, new ArrayList<>());
+        inDegree.put(node, 0);
+    }
+
+    /**
+     * adds a directed edge indicating that {@code from} must come before {@code to}.
+     * increments the in-degree of {@code to}.
+     *
+     * @param from the predecessor node
+     * @param to   the successor node
+     */
+    public void addEdge(T from, T to) {
+        adjacency.get(from).add(to);
+        inDegree.put(to, inDegree.get(to) + 1);
+    }
+
+    /**
+     * returns all nodes in insertion order.
+     *
+     * @return the node list
+     */
+    public List<T> getNodes() {
+        return nodes;
+    }
+
+    /**
+     * returns the adjacency list (outgoing neighbours) for the given node.
+     *
+     * @param node the node to query
+     * @return the list of successor nodes
+     */
+    public List<T> getNeighbours(T node) {
+        return adjacency.get(node);
+    }
+
+    /**
+     * returns the in-degree (number of incoming edges) for the given node.
+     *
+     * @param node the node to query
+     * @return the in-degree count
+     */
+    public int getInDegree(T node) {
+        return inDegree.get(node);
+    }
+
+    /**
+     * returns the total number of nodes in the graph.
+     *
+     * @return the node count
+     */
+    public int size() {
+        return nodes.size();
+    }
+}

--- a/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
+++ b/core/src/main/java/com/p1_7/abstractengine/engine/Engine.java
@@ -155,7 +155,8 @@ public class Engine {
      */
     public void init() {
         // build sorted order from dependency graph
-        List<IManager> sorted = topologicalSort();
+        DependencySorter sorter = new DependencySorter();
+        List<IManager> sorted = sorter.sort(managers, managerMap);
 
         // reorder managers list to sorted result
         managers.clear();
@@ -202,94 +203,6 @@ public class Engine {
         for (int i = 0; i < managers.size(); i++) {
             managers.get(i).init();
         }
-    }
-
-    /**
-     * topologically sorts managers using kahn's algorithm. managers with no
-     * dependency relationship retain their original registration order.
-     *
-     * @return managers in dependency-resolved order
-     * @throws IllegalArgumentException if a dependency type is not registered
-     * @throws IllegalStateException    if a circular dependency is detected
-     */
-    private List<IManager> topologicalSort() {
-        int n = managers.size();
-
-        // map each manager to its index for fast lookup
-        Map<IManager, Integer> indexOf = new HashMap<>(n);
-        for (int i = 0; i < n; i++) {
-            indexOf.put(managers.get(i), i);
-        }
-
-        // build adjacency list and in-degree count
-        // edge: dependency -> dependant (dependency must come first)
-        List<List<Integer>> adjacency = new ArrayList<>(n);
-        int[] inDegree = new int[n];
-        for (int i = 0; i < n; i++) {
-            adjacency.add(new ArrayList<>());
-        }
-
-        for (int i = 0; i < n; i++) {
-            IManager m = managers.get(i);
-            if (!(m instanceof Manager)) {
-                continue;
-            }
-            Class<? extends IManager>[] deps = ((Manager) m).getDependencies();
-            for (Class<? extends IManager> depType : deps) {
-                IManager depManager = managerMap.get(depType);
-                if (depManager == null) {
-                    throw new IllegalArgumentException(
-                        m.getClass().getSimpleName()
-                        + " depends on " + depType.getSimpleName()
-                        + " but no such manager is registered");
-                }
-                Integer depIndex = indexOf.get(depManager);
-                // edge from dependency to dependant
-                adjacency.get(depIndex).add(i);
-                inDegree[i]++;
-            }
-        }
-
-        // seed queue with zero-in-degree nodes in registration order (fifo for stability)
-        List<Integer> queue = new ArrayList<>();
-        int head = 0;
-        for (int i = 0; i < n; i++) {
-            if (inDegree[i] == 0) {
-                queue.add(i);
-            }
-        }
-
-        List<IManager> sorted = new ArrayList<>(n);
-        while (head < queue.size()) {
-            int current = queue.get(head++);
-            sorted.add(managers.get(current));
-
-            for (int j = 0; j < adjacency.get(current).size(); j++) {
-                int neighbour = adjacency.get(current).get(j);
-                inDegree[neighbour]--;
-                if (inDegree[neighbour] == 0) {
-                    queue.add(neighbour);
-                }
-            }
-        }
-
-        if (sorted.size() != n) {
-            // identify managers involved in the cycle
-            StringBuilder cycleInfo = new StringBuilder("circular dependency detected among: ");
-            boolean first = true;
-            for (int i = 0; i < n; i++) {
-                if (inDegree[i] > 0) {
-                    if (!first) {
-                        cycleInfo.append(", ");
-                    }
-                    cycleInfo.append(managers.get(i).getClass().getSimpleName());
-                    first = false;
-                }
-            }
-            throw new IllegalStateException(cycleInfo.toString());
-        }
-
-        return sorted;
     }
 
     /**


### PR DESCRIPTION
Move the generic directed acyclic graph (adjacency list, in-degree tracking) into DirectedAcyclicGraph<T> and the manager-specific topological sort into DependencySorter, replacing the private topologicalSort() method in Engine.