### PR TITLE
feat: scaffold game package with platform adapters, entities, and settings

### DIFF
--- a/core/src/main/java/com/p1_7/game/Main.java
+++ b/core/src/main/java/com/p1_7/game/Main.java
@@ -1,0 +1,66 @@
+package com.p1_7.game;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+
+import com.p1_7.abstractengine.engine.Engine;
+import com.p1_7.abstractengine.entity.EntityManager;
+import com.p1_7.abstractengine.input.InputManager;
+import com.p1_7.abstractengine.scene.SceneManager;
+
+import com.p1_7.game.platform.GdxInputSource;
+import com.p1_7.game.platform.GdxRenderManager;
+import com.p1_7.game.scenes.HelloWorldScene;
+
+/**
+ * Entry point for the game application.
+ *
+ * Bootstraps the engine with the minimum set of managers required to
+ * display the hello-world scene: entity management, rendering, and
+ * scene orchestration.
+ */
+public class Main extends ApplicationAdapter {
+
+    private Engine engine;
+
+    /**
+     * Initialises the engine and registers all managers and scenes.
+     * Called once by libGDX when the application window is ready.
+     */
+    @Override
+    public void create() {
+        engine = new Engine();
+
+        // core managers, registration order does not matter;
+        // engine reorders managers via topological sort on a directed acyclic graph.
+        engine.registerManager(new EntityManager());
+        engine.registerManager(new InputManager(new GdxInputSource()));
+        engine.registerManager(new GdxRenderManager());
+
+        // scene setup
+        SceneManager sceneManager = new SceneManager();
+        sceneManager.registerScene(new HelloWorldScene());
+        sceneManager.setInitialScene("hello");
+        engine.registerManager(sceneManager);
+
+        engine.init();
+    }
+
+    /**
+     * Called every frame by libGDX. Delegates update and render to the engine.
+     */
+    @Override
+    public void render() {
+        engine.update(Gdx.graphics.getDeltaTime());
+        engine.render();
+    }
+
+    /**
+     * Called by libGDX when the application is closing.
+     * Shuts down all managers in reverse dependency order.
+     */
+    @Override
+    public void dispose() {
+        engine.shutdown();
+    }
+}

--- a/core/src/main/java/com/p1_7/game/Settings.java
+++ b/core/src/main/java/com/p1_7/game/Settings.java
@@ -1,0 +1,31 @@
+package com.p1_7.game;
+
+/**
+ * Game application configuration values.
+ *
+ * All fields are public static so that any game class can read or
+ * override them at startup. The default values mirror those set in
+ * Lwjgl3Launcher; if the launcher changes the window size the game
+ * should update these fields accordingly.
+ */
+public class Settings {
+
+    /** width of the application window in pixels */
+    public static int WINDOW_WIDTH = 1280;
+
+    /** height of the application window in pixels */
+    public static int WINDOW_HEIGHT = 720;
+
+    /** music volume level (0.0 = silent, 1.0 = maximum) */
+    public static float MUSIC_VOLUME = 0.5f; // default 50% volume
+
+    /**
+     * Sets the music volume with validation.
+     * Clamps the value between 0.0 (silent) and 1.0 (maximum).
+     *
+     * @param volume the desired volume level
+     */
+    public static void setMusicVolume(float volume) {
+        MUSIC_VOLUME = Math.max(0f, Math.min(1f, volume));
+    }
+}

--- a/core/src/main/java/com/p1_7/game/core/Transform2D.java
+++ b/core/src/main/java/com/p1_7/game/core/Transform2D.java
@@ -1,0 +1,58 @@
+package com.p1_7.game.core;
+
+import com.p1_7.abstractengine.transform.ITransform;
+
+/**
+ * concrete 2D implementation of ITransform.
+ *
+ * manages position (x, y) and size (width, height) in 2D space.
+ * per-axis indexed accessors prevent external mutation of internal arrays.
+ */
+public class Transform2D implements ITransform {
+
+    // x, y coordinates
+    private float[] position = new float[2];
+
+    // width, height dimensions
+    private float[] size = new float[2];
+
+    /**
+     * constructs a 2D transform with the specified position and size.
+     *
+     * @param x      the x coordinate
+     * @param y      the y coordinate
+     * @param width  the width
+     * @param height the height
+     */
+    public Transform2D(float x, float y, float width, float height) {
+        this.position[0] = x;
+        this.position[1] = y;
+        this.size[0] = width;
+        this.size[1] = height;
+    }
+
+    @Override
+    public float getPosition(int axis) {
+        return position[axis];
+    }
+
+    @Override
+    public void setPosition(int axis, float value) {
+        position[axis] = value;
+    }
+
+    @Override
+    public float getSize(int axis) {
+        return size[axis];
+    }
+
+    @Override
+    public void setSize(int axis, float value) {
+        size[axis] = value;
+    }
+
+    @Override
+    public int getDimensions() {
+        return 2;
+    }
+}

--- a/core/src/main/java/com/p1_7/game/entities/HelloWorldText.java
+++ b/core/src/main/java/com/p1_7/game/entities/HelloWorldText.java
@@ -1,0 +1,82 @@
+package com.p1_7.game.entities;
+
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.p1_7.abstractengine.entity.Entity;
+import com.p1_7.abstractengine.render.ICustomRenderable;
+import com.p1_7.abstractengine.render.IRenderItem;
+import com.p1_7.abstractengine.render.IShapeRenderer;
+import com.p1_7.abstractengine.render.ISpriteBatch;
+import com.p1_7.abstractengine.transform.ITransform;
+import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.platform.GdxShapeRenderer;
+import com.p1_7.game.platform.GdxSpriteBatch;
+
+/**
+ * A renderable entity that draws a string using a BitmapFont.
+ *
+ * Returns null from getAssetPath() to signal the render manager that it
+ * should call renderCustom() instead of the standard sprite path. Casts
+ * the engine-provided batch and shapeRenderer to their libGDX wrappers so
+ * that BitmapFont.draw() can access the underlying SpriteBatch.
+ */
+public class HelloWorldText extends Entity implements IRenderItem, ICustomRenderable {
+
+    private final Transform2D transform;
+    private final BitmapFont font;
+    private final String text;
+
+    /**
+     * @param text  the string to display
+     * @param x     left edge of the text in screen coordinates
+     * @param y     baseline of the text in screen coordinates
+     * @param scale uniform scale applied to the default bitmap font
+     */
+    public HelloWorldText(String text, float x, float y, float scale) {
+        this.text = text;
+        this.transform = new Transform2D(x, y, 0f, 0f);
+        this.font = new BitmapFont();
+        this.font.getData().setScale(scale);
+    }
+
+    /**
+     * Returns null so the render manager routes this entity through
+     * the custom-rendering path rather than the sprite path.
+     */
+    @Override
+    public String getAssetPath() {
+        return null;
+    }
+
+    @Override
+    public ITransform getTransform() {
+        return transform;
+    }
+
+    /**
+     * Draws the text using the underlying libGDX sprite batch.
+     *
+     * The render manager leaves the shape renderer open when it calls this
+     * method, so we must end it before opening the batch, then restore it
+     * afterwards so subsequent custom renderables work correctly.
+     *
+     * @param batch         the engine sprite batch (cast to GdxSpriteBatch)
+     * @param shapeRenderer the engine shape renderer (cast to GdxShapeRenderer)
+     */
+    @Override
+    public void renderCustom(ISpriteBatch batch, IShapeRenderer shapeRenderer) {
+        // close the shape renderer before opening the sprite batch
+        ((GdxShapeRenderer) shapeRenderer).unwrap().end();
+        ((GdxSpriteBatch) batch).unwrap().begin();
+
+        font.draw(
+                ((GdxSpriteBatch) batch).unwrap(),
+                text,
+                transform.getPosition(0),
+                transform.getPosition(1));
+
+        // restore the shape renderer for any subsequent custom renderables
+        ((GdxSpriteBatch) batch).unwrap().end();
+        ((GdxShapeRenderer) shapeRenderer).unwrap().begin(ShapeType.Filled);
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxAssetStore.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxAssetStore.java
@@ -1,0 +1,39 @@
+package com.p1_7.game.platform;
+
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.Texture;
+import com.p1_7.abstractengine.render.IAssetStore;
+
+/**
+ * libgdx implementation of IAssetStore that wraps an AssetManager.
+ */
+public class GdxAssetStore implements IAssetStore {
+
+    /** the underlying libgdx asset manager */
+    private final AssetManager assetManager = new AssetManager();
+
+    /**
+     * loads a texture from the given asset path, blocking until ready.
+     *
+     * @param assetPath the relative path to the texture file
+     * @return the loaded libgdx Texture
+     */
+    @Override
+    public Object loadTexture(String assetPath) {
+        if (!assetManager.isLoaded(assetPath, Texture.class)) {
+            assetManager.load(assetPath, Texture.class);
+            assetManager.finishLoading();
+        }
+        return assetManager.get(assetPath, Texture.class);
+    }
+
+    @Override
+    public void finishLoading() {
+        assetManager.finishLoading();
+    }
+
+    @Override
+    public void dispose() {
+        assetManager.dispose();
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxInputSource.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxInputSource.java
@@ -1,0 +1,32 @@
+package com.p1_7.game.platform;
+
+import com.badlogic.gdx.Gdx;
+import com.p1_7.abstractengine.input.IInputSource;
+
+/**
+ * libgdx implementation of IInputSource that delegates to Gdx.input.
+ */
+public class GdxInputSource implements IInputSource {
+
+    /**
+     * returns whether the specified keyboard key is currently pressed.
+     *
+     * @param keyCode the libgdx key code
+     * @return true if the key is held down
+     */
+    @Override
+    public boolean isKeyPressed(int keyCode) {
+        return Gdx.input.isKeyPressed(keyCode);
+    }
+
+    /**
+     * returns whether the specified mouse button is currently pressed.
+     *
+     * @param buttonCode the libgdx button code
+     * @return true if the button is held down
+     */
+    @Override
+    public boolean isButtonPressed(int buttonCode) {
+        return Gdx.input.isButtonPressed(buttonCode);
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxRenderManager.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxRenderManager.java
@@ -1,0 +1,27 @@
+package com.p1_7.game.platform;
+
+import com.p1_7.abstractengine.render.IAssetStore;
+import com.p1_7.abstractengine.render.IShapeRenderer;
+import com.p1_7.abstractengine.render.ISpriteBatch;
+import com.p1_7.abstractengine.render.RenderManager;
+
+/**
+ * libgdx-specific render manager that provides concrete drawing resources.
+ */
+public class GdxRenderManager extends RenderManager {
+
+    @Override
+    protected ISpriteBatch createSpriteBatch() {
+        return new GdxSpriteBatch();
+    }
+
+    @Override
+    protected IShapeRenderer createShapeRenderer() {
+        return new GdxShapeRenderer();
+    }
+
+    @Override
+    protected IAssetStore createAssetStore() {
+        return new GdxAssetStore();
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxShapeRenderer.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxShapeRenderer.java
@@ -1,0 +1,39 @@
+package com.p1_7.game.platform;
+
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.p1_7.abstractengine.render.IShapeRenderer;
+
+/**
+ * libgdx implementation of IShapeRenderer that wraps a ShapeRenderer.
+ */
+public class GdxShapeRenderer implements IShapeRenderer {
+
+    /** the underlying libgdx shape renderer */
+    private final ShapeRenderer renderer = new ShapeRenderer();
+
+    @Override
+    public void begin() {
+        renderer.begin(ShapeType.Filled);
+    }
+
+    @Override
+    public void end() {
+        renderer.end();
+    }
+
+    @Override
+    public void dispose() {
+        renderer.dispose();
+    }
+
+    /**
+     * exposes the underlying libgdx ShapeRenderer for game code that
+     * requires direct access (e.g. setColor, rect).
+     *
+     * @return the wrapped ShapeRenderer
+     */
+    public ShapeRenderer unwrap() {
+        return renderer;
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxSpriteBatch.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxSpriteBatch.java
@@ -1,0 +1,53 @@
+package com.p1_7.game.platform;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.p1_7.abstractengine.render.ISpriteBatch;
+
+/**
+ * libgdx implementation of ISpriteBatch that wraps a SpriteBatch.
+ */
+public class GdxSpriteBatch implements ISpriteBatch {
+
+    /** the underlying libgdx sprite batch */
+    private final SpriteBatch batch = new SpriteBatch();
+
+    @Override
+    public void begin() {
+        batch.begin();
+    }
+
+    @Override
+    public void end() {
+        batch.end();
+    }
+
+    /**
+     * draws a texture at the specified position and size.
+     *
+     * @param textureHandle the loaded texture (must be a libgdx Texture)
+     * @param x             the x position
+     * @param y             the y position
+     * @param width         the draw width
+     * @param height        the draw height
+     */
+    @Override
+    public void draw(Object textureHandle, float x, float y, float width, float height) {
+        batch.draw((Texture) textureHandle, x, y, width, height);
+    }
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+    }
+
+    /**
+     * exposes the underlying libgdx SpriteBatch for game code that
+     * requires direct access (e.g. BitmapFont.draw).
+     *
+     * @return the wrapped SpriteBatch
+     */
+    public SpriteBatch unwrap() {
+        return batch;
+    }
+}

--- a/core/src/main/java/com/p1_7/game/scenes/HelloWorldScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/HelloWorldScene.java
@@ -1,0 +1,66 @@
+package com.p1_7.game.scenes;
+
+import com.p1_7.abstractengine.scene.Scene;
+import com.p1_7.abstractengine.scene.SceneContext;
+import com.p1_7.game.Settings;
+import com.p1_7.game.entities.HelloWorldText;
+
+/**
+ * A minimal scene that renders a centred "Hello, World!" message.
+ *
+ * The text entity implements ICustomRenderable directly, following the
+ * pattern described in the engine API guide.
+ */
+public class HelloWorldScene extends Scene {
+
+    /** the text entity submitted to the render queue each frame */
+    private HelloWorldText helloText;
+
+    public HelloWorldScene() {
+        this.name = "hello";
+    }
+
+    /**
+     * Creates the text entity, centred horizontally and vertically.
+     *
+     * @param context provides access to engine subsystems
+     */
+    @Override
+    public void onEnter(SceneContext context) {
+        // position the text roughly in the centre of the window
+        float x = Settings.WINDOW_WIDTH / 2f - 90f;
+        float y = Settings.WINDOW_HEIGHT / 2f;
+        helloText = new HelloWorldText("Hello, World!", x, y, 2.0f);
+    }
+
+    /**
+     * Nothing to clean up when leaving this scene.
+     *
+     * @param context provides access to engine subsystems
+     */
+    @Override
+    public void onExit(SceneContext context) {
+        // nothing to dispose
+    }
+
+    /**
+     * No interactive logic for a static hello-world scene.
+     *
+     * @param deltaTime seconds elapsed since last frame
+     * @param context   provides access to engine subsystems
+     */
+    @Override
+    public void update(float deltaTime, SceneContext context) {
+        // nothing to update
+    }
+
+    /**
+     * Queues the text entity for rendering this frame.
+     *
+     * @param context provides access to the render queue
+     */
+    @Override
+    public void submitRenderable(SceneContext context) {
+        context.renderQueue().queue(helloText);
+    }
+}

--- a/lwjgl3/src/main/java/com/p1_7/abstractengine/lwjgl3/Lwjgl3Launcher.java
+++ b/lwjgl3/src/main/java/com/p1_7/abstractengine/lwjgl3/Lwjgl3Launcher.java
@@ -2,7 +2,8 @@ package com.p1_7.abstractengine.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
-import com.p1_7.demo.Main;
+import com.p1_7.game.Main;
+import com.p1_7.game.Settings;
 
 /** Launches the desktop (LWJGL3) application. */
 public class Lwjgl3Launcher {
@@ -28,7 +29,7 @@ public class Lwjgl3Launcher {
         //// useful for testing performance, but can also be very stressful to some hardware.
         //// You may also need to configure GPU drivers to fully disable Vsync; this can cause screen tearing.
 
-        configuration.setWindowedMode(640, 480);
+        configuration.setWindowedMode(Settings.WINDOW_WIDTH, Settings.WINDOW_HEIGHT);
         //// You can change these files; they are in lwjgl3/src/main/resources/ .
         //// They can also be loaded from the root of assets/ .
         configuration.setWindowIcon("libgdx128.png", "libgdx64.png", "libgdx32.png", "libgdx16.png");


### PR DESCRIPTION
- Introduces the `com.p1_7.game` package containing the game entry point `Main.java`, platform GDX adapters (render, input, assets, sprites, shapes), a `HelloWorld` scene and entity, a `Transform2D` component, and a `Settings` class. 
- `Lwjgl3Launcher` is updated to import from the new package and read window dimensions from Settings (1280x720) instead of hardcoding 640x480.