### PR TITLE
feat: input manager interface

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/input/IInputManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/IInputManager.java
@@ -1,0 +1,12 @@
+package com.p1_7.abstractengine.input;
+
+/**
+ * unified input interface that combines read-only action queries with
+ * write-side key/button remapping.
+ *
+ * this type is intended for configuration and setup code (e.g. game
+ * initialisation or a key-rebinding screen) that needs to bind keys and
+ * query input state in the same place.
+ */
+public interface IInputManager extends IInputQuery, IInputMapping {
+}

--- a/core/src/main/java/com/p1_7/abstractengine/input/IInputMapping.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/IInputMapping.java
@@ -1,0 +1,69 @@
+package com.p1_7.abstractengine.input;
+
+import java.util.List;
+
+/**
+ * write-side interface for modifying key/button → action bindings at runtime.
+ */
+public interface IInputMapping {
+
+    /**
+     * binds a keyboard key to a logical action, replacing any existing
+     * binding for that key.
+     *
+     * @param keyCode  the platform key code to bind
+     * @param actionId the logical action to associate with the key
+     * @throws IllegalArgumentException if actionId is null
+     */
+    void bindKey(int keyCode, ActionId actionId);
+
+    /**
+     * removes the binding for the given keyboard key, if one exists.
+     *
+     * @param keyCode the platform key code to unbind
+     */
+    void unbindKey(int keyCode);
+
+    /**
+     * returns every key code currently mapped to the supplied action.
+     *
+     * @param actionId the action to search for
+     * @return a list of matching key codes (may be empty, never null)
+     * @throws IllegalArgumentException if actionId is null
+     */
+    List<Integer> getKeysForAction(ActionId actionId);
+
+    /**
+     * binds a controller button to a logical action, replacing any existing
+     * binding for that button.
+     *
+     * @param buttonCode the platform button code to bind
+     * @param actionId   the logical action to associate with the button
+     * @throws IllegalArgumentException if actionId is null
+     */
+    void bindButton(int buttonCode, ActionId actionId);
+
+    /**
+     * removes the binding for the given controller button, if one exists.
+     *
+     * @param buttonCode the platform button code to unbind
+     */
+    void unbindButton(int buttonCode);
+
+    /**
+     * removes all key and button bindings associated with the given action.
+     *
+     * @param actionId the action whose bindings should be removed
+     * @throws IllegalArgumentException if actionId is null
+     */
+    void unbindAction(ActionId actionId);
+
+    /**
+     * returns every button code currently mapped to the supplied action.
+     *
+     * @param actionId the action to search for
+     * @return a list of matching button codes (may be empty, never null)
+     * @throws IllegalArgumentException if actionId is null
+     */
+    List<Integer> getButtonsForAction(ActionId actionId);
+}

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputManager.java
@@ -9,9 +9,9 @@ import com.p1_7.abstractengine.engine.UpdatableManager;
 
 /**
  * polls physical input devices each frame and exposes derived action states
- * via IInputQuery.
+ * via IInputManager.
  */
-public class InputManager extends UpdatableManager implements IInputQuery {
+public class InputManager extends UpdatableManager implements IInputManager {
 
     /** the platform-specific input source for polling key and button state */
     private final IInputSource inputSource;
@@ -56,6 +56,10 @@ public class InputManager extends UpdatableManager implements IInputQuery {
 
         Set<ActionId> boundActions = getBoundActions();
 
+        // prune stale entries for actions that are no longer bound
+        actionStates.keySet().retainAll(boundActions);
+        previousDown.keySet().retainAll(boundActions);
+
         for (ActionId action : boundActions) {
             boolean currentlyDown = isPhysicallyDown(action);
             boolean wasDown = previousDown.getOrDefault(action, false);
@@ -99,12 +103,82 @@ public class InputManager extends UpdatableManager implements IInputQuery {
     }
 
     /**
-     * returns the input mapping used by this manager.
+     * binds a keyboard key to a logical action.
      *
-     * @return the current InputMapping
+     * @param keyCode  the platform key code to bind
+     * @param actionId the logical action to associate with the key
+     * @throws IllegalArgumentException if actionId is null
      */
-    public InputMapping getInputMapping() {
-        return inputMapping;
+    @Override
+    public void bindKey(int keyCode, ActionId actionId) {
+        inputMapping.bindKey(keyCode, actionId);
+    }
+
+    /**
+     * removes the binding for the given keyboard key, if one exists.
+     *
+     * @param keyCode the platform key code to unbind
+     */
+    @Override
+    public void unbindKey(int keyCode) {
+        inputMapping.unbindKey(keyCode);
+    }
+
+    /**
+     * returns every key code currently mapped to the supplied action.
+     *
+     * @param actionId the action to search for
+     * @return a list of matching key codes (may be empty, never null)
+     * @throws IllegalArgumentException if actionId is null
+     */
+    @Override
+    public List<Integer> getKeysForAction(ActionId actionId) {
+        return inputMapping.getKeysForAction(actionId);
+    }
+
+    /**
+     * binds a controller button to a logical action.
+     *
+     * @param buttonCode the platform button code to bind
+     * @param actionId   the logical action to associate with the button
+     * @throws IllegalArgumentException if actionId is null
+     */
+    @Override
+    public void bindButton(int buttonCode, ActionId actionId) {
+        inputMapping.bindButton(buttonCode, actionId);
+    }
+
+    /**
+     * removes the binding for the given controller button, if one exists.
+     *
+     * @param buttonCode the platform button code to unbind
+     */
+    @Override
+    public void unbindButton(int buttonCode) {
+        inputMapping.unbindButton(buttonCode);
+    }
+
+    /**
+     * removes all key and button bindings associated with the given action.
+     *
+     * @param actionId the action whose bindings should be removed
+     * @throws IllegalArgumentException if actionId is null
+     */
+    @Override
+    public void unbindAction(ActionId actionId) {
+        inputMapping.unbindAction(actionId);
+    }
+
+    /**
+     * returns every button code currently mapped to the supplied action.
+     *
+     * @param actionId the action to search for
+     * @return a list of matching button codes (may be empty, never null)
+     * @throws IllegalArgumentException if actionId is null
+     */
+    @Override
+    public List<Integer> getButtonsForAction(ActionId actionId) {
+        return inputMapping.getButtonsForAction(actionId);
     }
 
     /**

--- a/core/src/main/java/com/p1_7/abstractengine/input/InputMapping.java
+++ b/core/src/main/java/com/p1_7/abstractengine/input/InputMapping.java
@@ -20,13 +20,13 @@ public class InputMapping {
     private final Map<Integer, ActionId> buttonBindings = new HashMap<>();
 
     public InputMapping() {
-        resetToDefaults();
+        clearAllBindings();
     }
 
     /**
      * clears all key and button bindings.
      */
-    public void resetToDefaults() {
+    public void clearAllBindings() {
         keyBindings.clear();
         buttonBindings.clear();
     }
@@ -66,7 +66,11 @@ public class InputMapping {
         keyBindings.put(keyCode, actionId);
     }
 
-    // Unbinds keyboard key from map
+    /**
+     * removes the binding for the given keyboard key, if one exists.
+     *
+     * @param keyCode the key code to unbind
+     */
     public void unbindKey(int keyCode) {
         keyBindings.remove(keyCode);
     }
@@ -85,24 +89,28 @@ public class InputMapping {
         buttonBindings.put(buttonCode, actionId);
     }
 
-    // Unbinds button from map
+    /**
+     * removes the binding for the given controller button, if one exists.
+     *
+     * @param buttonCode the button code to unbind
+     */
     public void unbindButton(int buttonCode) {
         buttonBindings.remove(buttonCode);
     }
 
-    // Unbinds all keys and buttons mapped to the given action
-    public void unbindAction(ActionId action) {
-        if (action == null) {
-            throw new IllegalArgumentException("action cannot be null");
+    /**
+     * removes all key and button bindings associated with the given action.
+     *
+     * @param actionId the action whose bindings should be removed
+     * @throws IllegalArgumentException if actionId is null
+     */
+    public void unbindAction(ActionId actionId) {
+        if (actionId == null) {
+            throw new IllegalArgumentException("actionId cannot be null");
         }
 
-        if (keyBindings != null) {
-            keyBindings.entrySet().removeIf(entry -> entry.getValue() != null && entry.getValue().equals(action));
-        }
-
-        if (buttonBindings != null) {
-            buttonBindings.entrySet().removeIf(entry -> entry.getValue() != null && entry.getValue().equals(action));
-        }
+        keyBindings.entrySet().removeIf(entry -> entry.getValue().equals(actionId));
+        buttonBindings.entrySet().removeIf(entry -> entry.getValue().equals(actionId));
     }
 
     /**
@@ -110,11 +118,15 @@ public class InputMapping {
      *
      * @param actionId the action to search for
      * @return a list of matching key codes (may be empty)
+     * @throws IllegalArgumentException if actionId is null
      */
     public List<Integer> getKeysForAction(ActionId actionId) {
+        if (actionId == null) {
+            throw new IllegalArgumentException("actionId cannot be null");
+        }
         List<Integer> keys = new ArrayList<>();
         for (Map.Entry<Integer, ActionId> entry : keyBindings.entrySet()) {
-            if (entry.getValue() != null && entry.getValue().equals(actionId)) {
+            if (entry.getValue().equals(actionId)) {
                 keys.add(entry.getKey());
             }
         }
@@ -126,11 +138,15 @@ public class InputMapping {
      *
      * @param actionId the action to search for
      * @return a list of matching button codes (may be empty)
+     * @throws IllegalArgumentException if actionId is null
      */
     public List<Integer> getButtonsForAction(ActionId actionId) {
+        if (actionId == null) {
+            throw new IllegalArgumentException("actionId cannot be null");
+        }
         List<Integer> buttons = new ArrayList<>();
         for (Map.Entry<Integer, ActionId> entry : buttonBindings.entrySet()) {
-            if (entry.getValue() != null && entry.getValue().equals(actionId)) {
+            if (entry.getValue().equals(actionId)) {
                 buttons.add(entry.getKey());
             }
         }
@@ -146,15 +162,11 @@ public class InputMapping {
         Set<ActionId> actions = new HashSet<>();
 
         for (Map.Entry<Integer, ActionId> entry : keyBindings.entrySet()) {
-            if (entry.getValue() != null) {
-                actions.add(entry.getValue());
-            }
+            actions.add(entry.getValue());
         }
 
         for (Map.Entry<Integer, ActionId> entry : buttonBindings.entrySet()) {
-            if (entry.getValue() != null) {
-                actions.add(entry.getValue());
-            }
+            actions.add(entry.getValue());
         }
 
         return actions;

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
@@ -8,7 +8,7 @@ import com.p1_7.abstractengine.engine.ManagerResolver;
 import com.p1_7.abstractengine.engine.UpdatableManager;
 import com.p1_7.abstractengine.entity.EntityManager;
 import com.p1_7.abstractengine.entity.IEntityManager;
-import com.p1_7.abstractengine.input.IInputQuery;
+import com.p1_7.abstractengine.input.IInputManager;
 import com.p1_7.abstractengine.input.InputManager;
 import com.p1_7.abstractengine.render.IRenderQueue;
 import com.p1_7.abstractengine.render.RenderManager;
@@ -73,7 +73,7 @@ public class SceneManager extends UpdatableManager {
     public void onWire(ManagerResolver resolver) {
         serviceMap.put(IEntityManager.class, resolver.resolve(EntityManager.class));
         serviceMap.put(IRenderQueue.class,   resolver.resolve(RenderManager.class).getRenderQueue());
-        serviceMap.put(IInputQuery.class,    resolver.resolve(InputManager.class));
+        serviceMap.put(IInputManager.class,  resolver.resolve(InputManager.class));
     }
 
     /**

--- a/core/src/main/java/com/p1_7/demo/Main.java
+++ b/core/src/main/java/com/p1_7/demo/Main.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.Input;
 
 import com.p1_7.abstractengine.engine.Engine;
 import com.p1_7.abstractengine.entity.EntityManager;
-import com.p1_7.abstractengine.input.InputMapping;
 import com.p1_7.abstractengine.input.InputManager;
 import com.p1_7.abstractengine.movement.MovementManager;
 import com.p1_7.abstractengine.scene.SceneManager;
@@ -49,11 +48,10 @@ public class Main extends ApplicationAdapter {
         movementManager.setWorldBounds(worldMinBound, worldMaxBound);
 
         // 4. configure input bindings
-        InputMapping mapping = inputManager.getInputMapping();
-        mapping.bindKey(Input.Keys.LEFT, DemoActions.LEFT);
-        mapping.bindKey(Input.Keys.A, DemoActions.LEFT);
-        mapping.bindKey(Input.Keys.RIGHT, DemoActions.RIGHT);
-        mapping.bindKey(Input.Keys.D, DemoActions.RIGHT);
+        inputManager.bindKey(Input.Keys.LEFT, DemoActions.LEFT);
+        inputManager.bindKey(Input.Keys.A, DemoActions.LEFT);
+        inputManager.bindKey(Input.Keys.RIGHT, DemoActions.RIGHT);
+        inputManager.bindKey(Input.Keys.D, DemoActions.RIGHT);
 
         // 5. create and register all scenes
         MenuScene menuScene = new MenuScene();

--- a/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
@@ -9,7 +9,7 @@ import com.badlogic.gdx.utils.Array;
 import com.p1_7.abstractengine.collision.CollisionManager;
 import com.p1_7.abstractengine.entity.IEntityManager;
 import com.p1_7.abstractengine.entity.IEntityMutator;
-import com.p1_7.abstractengine.input.IInputQuery;
+import com.p1_7.abstractengine.input.IInputManager;
 import com.p1_7.abstractengine.movement.MovementManager;
 import com.p1_7.abstractengine.render.IRenderQueue;
 import com.p1_7.abstractengine.scene.Scene;
@@ -70,6 +70,11 @@ public class GameScene extends Scene {
 
     private final MovementManager movementManager;
     private final CollisionManager collisionManager;
+
+    // ==================== context services ====================
+
+    /** cached input manager reference, valid only between onEnter and onExit */
+    private IInputManager input;
 
     /**
      * constructs a game scene with references to required managers.
@@ -135,6 +140,9 @@ public class GameScene extends Scene {
 
         // 9. spawn initial droplet
         spawnDroplet(context.get(IEntityManager.class));
+
+        // cache input manager for use during update
+        this.input = context.get(IInputManager.class);
     }
 
     @Override
@@ -186,6 +194,8 @@ public class GameScene extends Scene {
             scoreDisplay.dispose();
             context.get(IEntityManager.class).removeEntity(scoreDisplay.getId());
         }
+
+        this.input = null;
     }
 
     @Override
@@ -233,7 +243,7 @@ public class GameScene extends Scene {
         }
 
         // 1. update bucket movement
-        bucket.updateMovement(context.get(IInputQuery.class));
+        bucket.updateMovement(input);
 
         // 2. update spawn timer and spawn new droplets
         spawnTimer += deltaTime;


### PR DESCRIPTION
## Summary
- Introduce `IInputManager` and `IInputMapping` interfaces, unifying action-query and key/button remapping behind a clean contract
- `InputManager` now implements `IInputManager` and delegates all binding operations to `InputMapping`
- Fix stale state bug: prune `actionStates` and `previousDown` entries for unbound actions in `onUpdate` via `retainAll`
- Add null guards to `InputMapping.getKeysForAction` and `getButtonsForAction`, replacing silent NPE with `IllegalArgumentException`
- Add `@throws IllegalArgumentException` to `IInputMapping` and corresponding `InputManager` delegation methods
- Remove misleading `IInputQuery` recommendation from `IInputManager` Javadoc — plumbing only registers under `IInputManager`
- Rename `resetToDefaults` → `clearAllBindings` to accurately reflect the method's behaviour
- Update `SceneManager`, `Main`, and `GameScene` to use `IInputManager` throughout

## Test plan
- [x] Project compiles with no errors (`./gradlew compileJava`)
- [ ] Game runs and player movement responds to LEFT/RIGHT and A/D keys
- [ ] Unbinding an action mid-session does not leave stale `PRESSED`/`HELD` state on subsequent frames
- [ ] Passing `null` to `getKeysForAction`, `getButtonsForAction`, or `unbindAction` throws `IllegalArgumentException`