### PR TITLE
fix: remove redundant extends IManager from IAudioManager

### DIFF
--- a/core/src/main/java/com/p1_7/game/managers/IAudioManager.java
+++ b/core/src/main/java/com/p1_7/game/managers/IAudioManager.java
@@ -1,14 +1,12 @@
 package com.p1_7.game.managers;
 
-import com.p1_7.abstractengine.engine.IManager;
-
 /**
  * Contract for game-level audio management.
  *
  * implementations handle loading and playback of music tracks and
  * sound effects, and expose volume control for the active track.
  */
-public interface IAudioManager extends IManager {
+public interface IAudioManager {
 
     /**
      * loads a music track into the cache under the given key.


### PR DESCRIPTION
## Summary
- `IAudioManager` extended `IManager`, but this was dead inheritance — `AudioManager extends Manager` and `Manager implements IManager` already satisfies the contract transitively.
- Removed the redundant `extends IManager` declaration and the unused `import com.p1_7.abstractengine.engine.IManager`.

Closes #35