### PR TITLE
fix: narrow submitRenderable to accept IRenderQueue instead of SceneContext

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/scene/Scene.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/Scene.java
@@ -1,5 +1,7 @@
 package com.p1_7.abstractengine.scene;
 
+import com.p1_7.abstractengine.render.IRenderQueue;
+
 /**
  * abstract base class for every scene; update is skipped while paused but
  * submitRenderable is always called.
@@ -54,9 +56,9 @@ public abstract class Scene {
      * per-frame hook where the scene pushes its visible entities into
      * the render queue. always called, even when the scene is paused.
      *
-     * @param context the current engine context
+     * @param renderQueue the render queue to submit items to
      */
-    public abstract void submitRenderable(SceneContext context);
+    public abstract void submitRenderable(IRenderQueue renderQueue);
 
     /**
      * returns the name (key) of this scene.

--- a/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/scene/SceneManager.java
@@ -300,7 +300,8 @@ public class SceneManager extends UpdatableManager {
             current.update(deltaTime, context);
         }
 
-        // always called
-        current.submitRenderable(context);
+        // resolve queue once and pass directly to avoid scene accessing full context
+        IRenderQueue renderQueue = (IRenderQueue) serviceMap.get(IRenderQueue.class);
+        current.submitRenderable(renderQueue);
     }
 }

--- a/core/src/main/java/com/p1_7/demo/scenes/GameOverScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/GameOverScene.java
@@ -98,13 +98,13 @@ public class GameOverScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
+    public void submitRenderable(IRenderQueue renderQueue) {
         // queue background first
-        context.get(IRenderQueue.class).queue(background);
+        renderQueue.queue(background);
 
         // queue text displays
-        context.get(IRenderQueue.class).queue(titleDisplay);
-        context.get(IRenderQueue.class).queue(scoreDisplay);
-        context.get(IRenderQueue.class).queue(promptDisplay);
+        renderQueue.queue(titleDisplay);
+        renderQueue.queue(scoreDisplay);
+        renderQueue.queue(promptDisplay);
     }
 }

--- a/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/GameScene.java
@@ -311,26 +311,26 @@ public class GameScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
+    public void submitRenderable(IRenderQueue renderQueue) {
         // background first (draws behind)
-        context.get(IRenderQueue.class).queue(background);
+        renderQueue.queue(background);
 
         // bucket
-        context.get(IRenderQueue.class).queue(bucket);
+        renderQueue.queue(bucket);
 
         // all active droplets
         for (int i = 0; i < droplets.size; i++) {
-            context.get(IRenderQueue.class).queue(droplets.get(i));
+            renderQueue.queue(droplets.get(i));
         }
 
         // clouds (draw above droplets but below ui)
         for (int i = 0; i < clouds.size; i++) {
-            context.get(IRenderQueue.class).queue(clouds.get(i));
+            renderQueue.queue(clouds.get(i));
         }
 
         // ui displays last (draw on top)
-        context.get(IRenderQueue.class).queue(livesDisplay);
-        context.get(IRenderQueue.class).queue(scoreDisplay);
+        renderQueue.queue(livesDisplay);
+        renderQueue.queue(scoreDisplay);
     }
 
     // ==================== helper methods ====================

--- a/core/src/main/java/com/p1_7/demo/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/MenuScene.java
@@ -72,12 +72,12 @@ public class MenuScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
+    public void submitRenderable(IRenderQueue renderQueue) {
         // queue background first
-        context.get(IRenderQueue.class).queue(background);
+        renderQueue.queue(background);
 
         // queue text displays
-        context.get(IRenderQueue.class).queue(titleDisplay);
-        context.get(IRenderQueue.class).queue(promptDisplay);
+        renderQueue.queue(titleDisplay);
+        renderQueue.queue(promptDisplay);
     }
 }

--- a/core/src/main/java/com/p1_7/demo/scenes/PauseScene.java
+++ b/core/src/main/java/com/p1_7/demo/scenes/PauseScene.java
@@ -167,20 +167,20 @@ public class PauseScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
+    public void submitRenderable(IRenderQueue renderQueue) {
         // queue background first
-        context.get(IRenderQueue.class).queue(background);
+        renderQueue.queue(background);
 
         // queue text displays
-        context.get(IRenderQueue.class).queue(titleDisplay);
-        context.get(IRenderQueue.class).queue(livesDisplay);
-        context.get(IRenderQueue.class).queue(scoreDisplay);
-        context.get(IRenderQueue.class).queue(volumeLabel);
+        renderQueue.queue(titleDisplay);
+        renderQueue.queue(livesDisplay);
+        renderQueue.queue(scoreDisplay);
+        renderQueue.queue(volumeLabel);
 
         // queue volume slider
-        context.get(IRenderQueue.class).queue(volumeSlider);
+        renderQueue.queue(volumeSlider);
 
         // queue resume prompt
-        context.get(IRenderQueue.class).queue(resumePrompt);
+        renderQueue.queue(resumePrompt);
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/HelloWorldScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/HelloWorldScene.java
@@ -61,7 +61,7 @@ public class HelloWorldScene extends Scene {
      * @param context provides access to the render queue
      */
     @Override
-    public void submitRenderable(SceneContext context) {
-        context.get(IRenderQueue.class).queue(helloText);
+    public void submitRenderable(IRenderQueue renderQueue) {
+        renderQueue.queue(helloText);
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -132,14 +132,14 @@ public class LevelCompleteScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
-        context.get(IRenderQueue.class).queue(background);
-        context.get(IRenderQueue.class).queue(title);
-        context.get(IRenderQueue.class).queue(promptStatus);
-        context.get(IRenderQueue.class).queue(btnContinue);
-        context.get(IRenderQueue.class).queue(btnMainMenu);
-        context.get(IRenderQueue.class).queue(hintSpace);
-        context.get(IRenderQueue.class).queue(hintEsc);
+    public void submitRenderable(IRenderQueue renderQueue) {
+        renderQueue.queue(background);
+        renderQueue.queue(title);
+        renderQueue.queue(promptStatus);
+        renderQueue.queue(btnContinue);
+        renderQueue.queue(btnMainMenu);
+        renderQueue.queue(hintSpace);
+        renderQueue.queue(hintEsc);
     }
 
     private boolean isLastLevel() {

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -140,12 +140,12 @@ public class MenuScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
-        context.get(IRenderQueue.class).queue(background);
-        context.get(IRenderQueue.class).queue(titleText);
-        context.get(IRenderQueue.class).queue(btnStart);
-        context.get(IRenderQueue.class).queue(btnSettings);
-        context.get(IRenderQueue.class).queue(btnExit);
+    public void submitRenderable(IRenderQueue renderQueue) {
+        renderQueue.queue(background);
+        renderQueue.queue(titleText);
+        renderQueue.queue(btnStart);
+        renderQueue.queue(btnSettings);
+        renderQueue.queue(btnExit);
     }
 
     // ── inner entities ────────────────────────────────────────────

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -149,8 +149,7 @@ public class SettingScene extends Scene {
     }
 
     @Override
-    public void submitRenderable(SceneContext context) {
-        IRenderQueue renderQueue = context.get(IRenderQueue.class);
+    public void submitRenderable(IRenderQueue renderQueue) {
         renderQueue.queue(background);
         renderQueue.queue(heading);
         renderQueue.queue(volumeLabel);


### PR DESCRIPTION
## Summary
- `submitRenderable(SceneContext)` gave scenes access to the full context (including `changeScene`, `get(IEntityManager.class)`, etc.) from inside a render hook — a wider surface than necessary.
- Changed the signature to `submitRenderable(IRenderQueue)` so only the render queue is reachable during render submission.
- `SceneManager.onUpdate` now resolves the queue once and passes it directly.
- Updated all 8 scene implementations (4 in `com.p1_7.demo.scenes`, 4 in `com.p1_7.game.scenes`).

Closes #36