### PR TITLE
fix: guard ICursorSource retrieval with hasExtension check in all scenes

### DIFF
--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -79,7 +79,10 @@ public class LevelCompleteScene extends Scene {
         generator.dispose();
 
         IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        if (inputRegistry.hasExtension(ICursorSource.class)) {
+            cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        }
+        // cursorSource stays null if not registered; update() guard handles it cleanly
 
         float cx = Settings.getWindowWidth() / 2f;
         float cy = Settings.getWindowHeight() / 2f;

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -74,7 +74,10 @@ public class MenuScene extends Scene {
         firstButtonY  = Settings.getWindowHeight() * 0.45f;
 
         IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        if (inputRegistry.hasExtension(ICursorSource.class)) {
+            cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        }
+        // cursorSource stays null if not registered; update() guard handles it cleanly
 
         IAudioManager audio = context.get(IAudioManager.class);
 

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -51,7 +51,6 @@ public class SettingScene extends Scene {
     private BitmapFont labelFont;
     private BitmapFont buttonFont;
 
-    // ── entities ─────────────────────────────────────────────────
     // ── input ────────────────────────────────────────────────────
     private ICursorSource cursorSource;
 
@@ -100,7 +99,10 @@ public class SettingScene extends Scene {
         generator.dispose(); // safe to dispose after generating all fonts
 
         IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        if (inputRegistry.hasExtension(ICursorSource.class)) {
+            cursorSource = inputRegistry.getExtension(ICursorSource.class);
+        }
+        // cursorSource stays null if not registered; update() guard handles it cleanly
 
         audio = context.get(IAudioManager.class);
 


### PR DESCRIPTION
## Summary

- `getExtension(ICursorSource.class)` in `onEnter()` was called unconditionally, throwing `IllegalArgumentException` if `ICursorSource` was not registered
- wraps the retrieval in `hasExtension()` guard across `MenuScene`, `SettingScene`, and `LevelCompleteScene` so `cursorSource` stays null gracefully when the extension is absent
- the existing `cursorSource != null` guard in each `update()` already handles the null case cleanly

## Test plan

- [x] Run with `ICursorSource` registered — confirm cursor-driven hover and click works in all three scenes
- [x] Run without `ICursorSource` registered — confirm no `IllegalArgumentException` is thrown on scene entry