### PR TITLE
feat: VolumeSlider entity

### DIFF
--- a/core/src/main/java/com/p1_7/game/entities/MenuButton.java
+++ b/core/src/main/java/com/p1_7/game/entities/MenuButton.java
@@ -173,12 +173,12 @@ public class MenuButton extends Entity implements IRenderable {
                                   x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
         } else {
             // ── procedural fallback ────────────────────────────
-            gdxCtx.fillRect(COLOUR_BORDER,
-                            x - BORDER_THICK, y - BORDER_THICK,
-                            BUTTON_WIDTH  + BORDER_THICK * 2,
-                            BUTTON_HEIGHT + BORDER_THICK * 2);
-            gdxCtx.fillRect(hovered ? COLOUR_HOVER : COLOUR_NORMAL,
-                            x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
+            gdxCtx.rect(COLOUR_BORDER,
+                        x - BORDER_THICK, y - BORDER_THICK,
+                        BUTTON_WIDTH  + BORDER_THICK * 2,
+                        BUTTON_HEIGHT + BORDER_THICK * 2, true);
+            gdxCtx.rect(hovered ? COLOUR_HOVER : COLOUR_NORMAL,
+                        x, y, BUTTON_WIDTH, BUTTON_HEIGHT, true);
         }
 
         // label drawn in both modes, centred over the button body

--- a/core/src/main/java/com/p1_7/game/entities/VolumeSlider.java
+++ b/core/src/main/java/com/p1_7/game/entities/VolumeSlider.java
@@ -1,0 +1,171 @@
+package com.p1_7.game.entities;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.Color;
+import com.p1_7.abstractengine.entity.Entity;
+import com.p1_7.abstractengine.render.IDrawContext;
+import com.p1_7.abstractengine.render.IRenderable;
+import com.p1_7.abstractengine.transform.ITransform;
+import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.input.ICursorSource;
+import com.p1_7.game.platform.GdxDrawContext;
+
+/**
+ * Horizontal volume slider entity.
+ *
+ * Renders a coloured track with a draggable circular knob. The knob position
+ * maps linearly to a [0.0, 1.0] value that callers read and forward to the
+ * audio manager.
+ *
+ * Usage pattern mirrors MenuButton:
+ *   call updateInput() every frame, check hasMoved(), then resetMoved().
+ *   call dispose() in the scene's onExit().
+ */
+public class VolumeSlider extends Entity implements IRenderable {
+
+    // ── dimensions ──────────────────────────────────────────────
+    private static final float KNOB_RADIUS  = 14f;
+    private static final float TRACK_HALF_H = 5f;
+
+    // ── colours (matching MenuButton procedural palette) ────────
+    private static final Color COLOUR_TRACK     = new Color(0.20f, 0.20f, 0.55f, 1f);
+    private static final Color COLOUR_FILLED    = new Color(0.80f, 0.80f, 1.00f, 1f);
+    private static final Color COLOUR_KNOB      = new Color(0.35f, 0.35f, 0.80f, 1f);
+    private static final Color COLOUR_KNOB_DRAG = Color.WHITE;
+
+    // ── geometry ────────────────────────────────────────────────
+    private final Transform2D transform;
+    private final float       trackLeft;
+    private final float       trackCentreY;
+    private final float       trackWidth;
+    private final float       knobRadius;
+
+    // ── state ────────────────────────────────────────────────────
+    /** current volume in [0.0, 1.0] */
+    private float   value;
+    /** true while the left mouse button is held on the knob */
+    private boolean dragging = false;
+    /** single-frame dirty flag; true when value changed this frame */
+    private boolean moved    = false;
+
+    // ── constructor ──────────────────────────────────────────────
+
+    /**
+     * Creates a volume slider centred at (centreX, centreY).
+     *
+     * @param centreX      horizontal centre of the slider in world coordinates
+     * @param centreY      vertical centre of the slider in world coordinates
+     * @param trackWidth   pixel span of the full draggable range
+     * @param initialValue starting knob position in [0.0, 1.0]; pass
+     *                     {@code IAudioManager.getMusicVolume()} from the scene
+     */
+    public VolumeSlider(float centreX, float centreY, float trackWidth, float initialValue) {
+        this.trackLeft    = centreX - trackWidth / 2f;
+        this.trackCentreY = centreY;
+        this.trackWidth   = trackWidth;
+        this.knobRadius   = KNOB_RADIUS;
+        this.value        = initialValue;
+
+        // bounding box encompasses the knob travel area
+        this.transform = new Transform2D(
+            trackLeft,
+            centreY - knobRadius,
+            trackWidth,
+            knobRadius * 2f
+        );
+    }
+
+    // ── per-frame input ──────────────────────────────────────────
+
+    /**
+     * Polls cursor position and drag state using the provided cursor source.
+     * Call once per frame from the scene's update().
+     *
+     * @param cursor the world-space cursor source (Y-flip already applied)
+     */
+    public void updateInput(ICursorSource cursor) {
+        float mx    = cursor.getCursorX();
+        float my    = cursor.getCursorY();
+        float knobX = trackLeft + value * trackWidth;
+
+        moved = false;
+
+        // start drag on press within the knob hit-area (1.5× radius for easier targeting)
+        if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
+            float dx           = mx - knobX;
+            float dy           = my - trackCentreY;
+            float hitRadius    = knobRadius * 1.5f;
+            if (dx * dx + dy * dy <= hitRadius * hitRadius) {
+                dragging = true;
+            }
+        }
+
+        // update value while dragging
+        if (dragging && Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            float clamped = Math.max(trackLeft, Math.min(trackLeft + trackWidth, mx));
+            value = (clamped - trackLeft) / trackWidth;
+            moved = true;
+        }
+
+        // release drag when button is no longer held
+        if (!Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            dragging = false;
+        }
+    }
+
+    // ── state query ──────────────────────────────────────────────
+
+    /**
+     * Returns the current slider value.
+     *
+     * @return value in [0.0, 1.0]
+     */
+    public float getValue() { return value; }
+
+    /**
+     * Returns true if the slider value changed this frame.
+     *
+     * @return true when a drag moved the knob since the last resetMoved() call
+     */
+    public boolean hasMoved() { return moved; }
+
+    /** Clears the moved flag — call after handling the value change. */
+    public void resetMoved() { moved = false; }
+
+    // ── IRenderable ──────────────────────────────────────────────
+
+    /** Returns null — this entity owns no managed assets. */
+    @Override public String     getAssetPath() { return null; }
+    @Override public ITransform getTransform() { return transform; }
+
+    /**
+     * Draws the track, filled portion, and knob.
+     * Pass transitions are managed by GdxDrawContext; no begin/end calls here.
+     *
+     * @param ctx the draw context for this frame
+     */
+    @Override
+    public void render(IDrawContext ctx) {
+        GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
+        float knobX = trackLeft + value * trackWidth;
+
+        // unfilled (background) track
+        gdxCtx.rect(COLOUR_TRACK,  trackLeft, trackCentreY - TRACK_HALF_H,
+                    trackWidth,              TRACK_HALF_H * 2f, true);
+
+        // filled (left) portion indicating the current volume level
+        gdxCtx.rect(COLOUR_FILLED, trackLeft, trackCentreY - TRACK_HALF_H,
+                    value * trackWidth,      TRACK_HALF_H * 2f, true);
+
+        // draggable knob; colour changes while held
+        gdxCtx.circle(dragging ? COLOUR_KNOB_DRAG : COLOUR_KNOB,
+                      knobX, trackCentreY, knobRadius, true);
+    }
+
+    /**
+     * No-op — this entity owns no GPU resources.
+     * Included for lifecycle symmetry with MenuButton.
+     */
+    public void dispose() { }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxDrawContext.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxDrawContext.java
@@ -26,7 +26,8 @@ public class GdxDrawContext implements IDrawContext {
     private final ShapeRenderer shapeRenderer;
     private final IAssetStore   assetStore;
 
-    private Pass currentPass = Pass.NONE;
+    private Pass                     currentPass      = Pass.NONE;
+    private ShapeRenderer.ShapeType  activeShapeType  = null;
 
     /**
      * constructs a draw context backed by the provided libgdx resources.
@@ -53,7 +54,8 @@ public class GdxDrawContext implements IDrawContext {
         } else if (currentPass == Pass.SHAPE) {
             shapeRenderer.end();
         }
-        currentPass = Pass.NONE;
+        currentPass     = Pass.NONE;
+        activeShapeType = null;
     }
 
     /**
@@ -104,18 +106,34 @@ public class GdxDrawContext implements IDrawContext {
     }
 
     /**
-     * fills a rectangle with the given colour.
+     * draws a rectangle with the given colour.
      *
-     * @param color the fill colour
-     * @param x     left edge in world coordinates
-     * @param y     bottom edge in world coordinates
-     * @param w     rectangle width
-     * @param h     rectangle height
+     * @param color  the colour
+     * @param x      left edge in world coordinates
+     * @param y      bottom edge in world coordinates
+     * @param w      width
+     * @param h      height
+     * @param filled true for a solid fill, false for an outline
      */
-    public void fillRect(Color color, float x, float y, float w, float h) {
-        openShape();
+    public void rect(Color color, float x, float y, float w, float h, boolean filled) {
+        openShape(filled ? ShapeRenderer.ShapeType.Filled : ShapeRenderer.ShapeType.Line);
         shapeRenderer.setColor(color);
         shapeRenderer.rect(x, y, w, h);
+    }
+
+    /**
+     * draws a circle with the given colour.
+     *
+     * @param color  the colour
+     * @param x      centre x in world coordinates
+     * @param y      centre y in world coordinates
+     * @param radius circle radius
+     * @param filled true for a solid fill, false for an outline
+     */
+    public void circle(Color color, float x, float y, float radius, boolean filled) {
+        openShape(filled ? ShapeRenderer.ShapeType.Filled : ShapeRenderer.ShapeType.Line);
+        shapeRenderer.setColor(color);
+        shapeRenderer.circle(x, y, radius);
     }
 
     // ── private pass management ───────────────────────────────────
@@ -135,16 +153,17 @@ public class GdxDrawContext implements IDrawContext {
     }
 
     /**
-     * ensures the shape renderer pass is open, closing the batch pass first if needed.
+     * ensures the shape renderer pass is open for the given shape type.
+     * re-opens the renderer if the type changes mid-frame.
+     *
+     * @param type the desired ShapeType (Filled or Line)
      */
-    private void openShape() {
-        if (currentPass == Pass.SHAPE) {
-            return;
-        }
-        if (currentPass == Pass.BATCH) {
-            batch.end();
-        }
-        shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
-        currentPass = Pass.SHAPE;
+    private void openShape(ShapeRenderer.ShapeType type) {
+        if (currentPass == Pass.SHAPE && activeShapeType == type) return;
+        if (currentPass == Pass.SHAPE) shapeRenderer.end();
+        else if (currentPass == Pass.BATCH) batch.end();
+        shapeRenderer.begin(type);
+        currentPass     = Pass.SHAPE;
+        activeShapeType = type;
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -21,6 +21,7 @@ import com.p1_7.game.core.Transform2D;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.managers.IAudioManager;
 import com.p1_7.game.entities.MenuButton;
+import com.p1_7.game.entities.VolumeSlider;
 import com.p1_7.game.platform.GdxDrawContext;
 
 /**
@@ -60,8 +61,7 @@ public class SettingScene extends Scene {
     private SettingsBackground background;
     private LabelText          heading;
     private LabelText          volumeLabel;
-    private MenuButton         volumeDownButton;
-    private MenuButton         volumeUpButton;
+    private VolumeSlider       volumeSlider;
     private MenuButton         backButton;
 
     public SettingScene() {
@@ -113,16 +113,14 @@ public class SettingScene extends Scene {
         volumeLabel = new LabelText(volumeText(audio), centreX, centreY + 60f,
                                     labelFont);
 
-        volumeDownButton = MenuButton.withTexture("-",    centreX - 170f, centreY - 10f,  buttonFont, BTN_ASSET, HOVER_ASSET);
-        volumeUpButton   = MenuButton.withTexture("+",    centreX + 170f, centreY - 10f,  buttonFont, BTN_ASSET, HOVER_ASSET);
-        backButton       = MenuButton.withTexture("BACK", centreX,        centreY - 120f, buttonFont, BTN_ASSET, HOVER_ASSET);
+        volumeSlider = new VolumeSlider(centreX, centreY - 10f, 340f, audio.getMusicVolume());
+        backButton   = MenuButton.withTexture("BACK", centreX, centreY - 120f, buttonFont, BTN_ASSET, HOVER_ASSET);
     }
 
     @Override
     public void onExit(SceneContext context) {
-        if (volumeDownButton != null) volumeDownButton.dispose();
-        if (volumeUpButton   != null) volumeUpButton.dispose();
-        if (backButton       != null) backButton.dispose();
+        if (volumeSlider != null) volumeSlider.dispose();
+        if (backButton   != null) backButton.dispose();
         if (background       != null) background.dispose();
         if (headingFont      != null) headingFont.dispose();
         if (labelFont        != null) labelFont.dispose();
@@ -140,19 +138,13 @@ public class SettingScene extends Scene {
         }
 
         if (cursorSource == null) return;
-        volumeDownButton.updateInput(cursorSource);
-        volumeUpButton.updateInput(cursorSource);
+        volumeSlider.updateInput(cursorSource);
         backButton.updateInput(cursorSource);
 
-        if (volumeDownButton.isClicked()) {
-            volumeDownButton.resetClick();
-            audio.setMusicVolume(audio.getMusicVolume() - 0.1f);
+        if (volumeSlider.hasMoved()) {
+            audio.setMusicVolume(volumeSlider.getValue());
             volumeLabel.setText(volumeText(audio));
-        }
-        if (volumeUpButton.isClicked()) {
-            volumeUpButton.resetClick();
-            audio.setMusicVolume(audio.getMusicVolume() + 0.1f);
-            volumeLabel.setText(volumeText(audio));
+            volumeSlider.resetMoved();
         }
         if (backButton.isClicked()) {
             backButton.resetClick();
@@ -165,8 +157,7 @@ public class SettingScene extends Scene {
         renderQueue.queue(background);
         renderQueue.queue(heading);
         renderQueue.queue(volumeLabel);
-        renderQueue.queue(volumeDownButton);
-        renderQueue.queue(volumeUpButton);
+        renderQueue.queue(volumeSlider);
         renderQueue.queue(backButton);
     }
 


### PR DESCRIPTION
## Summary
- Replaces the `+`/`-` `MenuButton` pair in `SettingScene` with a draggable horizontal `VolumeSlider` entity, resolving the UX issue raised in #30/#42
- `GdxDrawContext.fillRect` renamed to `rect(color, x, y, w, h, filled)` and a new `circle(color, x, y, radius, filled)` method added; `openShape` now accepts a `ShapeType` so filled and outlined shapes can coexist in the same frame without re-opening the renderer unnecessarily
- `MenuButton` procedural fallback updated to call `rect(..., true)` to match the new API
- `VolumeSlider` seeds its initial knob position from `IAudioManager.getMusicVolume()` (not `Settings` directly) to honour the audio manager as the single source of truth for volume

## Test plan
- [x] Navigate to Settings scene — confirm no `+`/`-` buttons; horizontal slider is visible
- [x] Drag knob to far left → `Music Volume: 0%`; far right → `Music Volume: 100%`
- [x] Drag to mid-point → label updates live to the correct percentage
- [x] Confirm music volume audibly changes during drag
- [x] Exit and re-enter Settings — slider knob initialises to the saved volume position
- [x] Press ESC / Backspace — scene returns to the menu without errors

Closes #42 