### PR TITLE
feat: BrightnessSlider and BrightnessOverlay entities

### DIFF
--- a/core/src/main/java/com/p1_7/abstractengine/render/IDrawContext.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/IDrawContext.java
@@ -12,4 +12,10 @@ public interface IDrawContext {
      * called by the render manager once after all items have been rendered.
      */
     void flush();
+
+    /**
+     * releases any draw-context-owned resources.
+     * called by the render manager during shutdown.
+     */
+    void dispose();
 }

--- a/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
+++ b/core/src/main/java/com/p1_7/abstractengine/render/RenderManager.java
@@ -73,6 +73,7 @@ public abstract class RenderManager extends Manager {
      */
     @Override
     protected void onShutdown() {
+        if (drawCtx       != null) { drawCtx.dispose(); }
         if (assetStore    != null) { assetStore.dispose(); }
         if (batch         != null) { batch.dispose(); }
         if (shapeRenderer != null) { shapeRenderer.dispose(); }

--- a/core/src/main/java/com/p1_7/game/Settings.java
+++ b/core/src/main/java/com/p1_7/game/Settings.java
@@ -10,6 +10,12 @@ package com.p1_7.game;
  */
 public class Settings {
 
+    /** lowest supported brightness level; used to avoid a fully black screen */
+    public static final float MIN_BRIGHTNESS_LEVEL = 0.1f;
+
+    /** default brightness level used on startup */
+    public static final float DEFAULT_BRIGHTNESS_LEVEL = 0.9f;
+
     /**
      * Preset resolution options available to the player.
      *
@@ -44,7 +50,7 @@ public class Settings {
     private static int   windowWidth     = 1280;
     private static int   windowHeight    = 720;
     private static float musicVolume     = 0.5f;
-    private static float brightnessLevel = 0.0f;
+    private static float brightnessLevel = DEFAULT_BRIGHTNESS_LEVEL;
 
     /** returns the window width in pixels */
     public static int getWindowWidth() { return windowWidth; }
@@ -55,7 +61,7 @@ public class Settings {
     /** returns the music volume in the range [0.0, 1.0] */
     public static float getMusicVolume() { return musicVolume; }
 
-    /** returns the brightness overlay level in the range [0.0, 1.0] */
+    /** returns the screen brightness level in the range [0.1, 1.0] */
     public static float getBrightnessLevel() { return brightnessLevel; }
 
     /**
@@ -68,12 +74,12 @@ public class Settings {
     }
 
     /**
-     * Sets the brightness overlay level, clamped to the valid range [0.0, 1.0].
+     * Sets the screen brightness level, clamped to the valid range [0.1, 1.0].
      *
-     * @param level the desired brightness level; values outside [0.0, 1.0] are clamped
+     * @param level the desired brightness level; values outside [0.1, 1.0] are clamped
      */
     public static void setBrightnessLevel(float level) {
-        brightnessLevel = Math.max(0.0f, Math.min(1.0f, level));
+        brightnessLevel = Math.max(MIN_BRIGHTNESS_LEVEL, Math.min(1.0f, level));
     }
 
     /**

--- a/core/src/main/java/com/p1_7/game/entities/BrightnessOverlay.java
+++ b/core/src/main/java/com/p1_7/game/entities/BrightnessOverlay.java
@@ -1,0 +1,52 @@
+package com.p1_7.game.entities;
+
+import com.badlogic.gdx.graphics.Color;
+import com.p1_7.abstractengine.entity.Entity;
+import com.p1_7.abstractengine.render.IDrawContext;
+import com.p1_7.abstractengine.render.IRenderable;
+import com.p1_7.abstractengine.transform.ITransform;
+import com.p1_7.game.Settings;
+import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.platform.GdxDrawContext;
+
+/**
+ * Full-screen brightness overlay.
+ *
+ * Draws a translucent black quad whose alpha is the inverse of the current
+ * brightness setting, allowing scenes to dim the entire frame when queued last.
+ */
+public class BrightnessOverlay extends Entity implements IRenderable {
+
+    private final Transform2D transform;
+    private final Color       overlayColour = new Color(0f, 0f, 0f, 1f);
+
+    /** Creates a full-screen overlay sized from the current settings. */
+    public BrightnessOverlay() {
+        this.transform = new Transform2D(
+            0f,
+            0f,
+            Settings.getWindowWidth(),
+            Settings.getWindowHeight()
+        );
+    }
+
+    @Override public String     getAssetPath() { return null; }
+    @Override public ITransform getTransform() { return transform; }
+
+    /**
+     * Draws the overlay with alpha driven by the current brightness level.
+     *
+     * @param ctx the draw context for this frame
+     */
+    @Override
+    public void render(IDrawContext ctx) {
+        GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
+        overlayColour.a = 1.0f - Settings.getBrightnessLevel();
+        gdxCtx.drawTintedQuad(overlayColour,
+                              transform.getPosition(0), transform.getPosition(1),
+                              transform.getSize(0),     transform.getSize(1));
+    }
+
+    /** No-op — this entity owns no disposable resources. */
+    public void dispose() { }
+}

--- a/core/src/main/java/com/p1_7/game/entities/BrightnessSlider.java
+++ b/core/src/main/java/com/p1_7/game/entities/BrightnessSlider.java
@@ -1,0 +1,150 @@
+package com.p1_7.game.entities;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.Color;
+import com.p1_7.abstractengine.entity.Entity;
+import com.p1_7.abstractengine.render.IDrawContext;
+import com.p1_7.abstractengine.render.IRenderable;
+import com.p1_7.abstractengine.transform.ITransform;
+import com.p1_7.game.Settings;
+import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.input.ICursorSource;
+import com.p1_7.game.platform.GdxDrawContext;
+
+/**
+ * Horizontal brightness slider entity.
+ *
+ * Behaves like VolumeSlider, but writes the dragged value directly through
+ * Settings.setBrightnessLevel(float). The slider range is [0.1, 1.0].
+ */
+public class BrightnessSlider extends Entity implements IRenderable {
+
+    private static final float KNOB_RADIUS  = 14f;
+    private static final float TRACK_HALF_H = 5f;
+    private static final float MIN_VALUE    = Settings.MIN_BRIGHTNESS_LEVEL;
+    private static final float VALUE_RANGE  = 1.0f - MIN_VALUE;
+
+    private static final Color COLOUR_TRACK     = new Color(0.20f, 0.20f, 0.55f, 1f);
+    private static final Color COLOUR_FILLED    = new Color(1.00f, 0.88f, 0.42f, 1f);
+    private static final Color COLOUR_KNOB      = new Color(0.82f, 0.64f, 0.18f, 1f);
+    private static final Color COLOUR_KNOB_DRAG = Color.WHITE;
+
+    private final Transform2D transform;
+    private final float       trackLeft;
+    private final float       trackCentreY;
+    private final float       trackWidth;
+    private final float       knobRadius;
+
+    private float   value;
+    private boolean dragging = false;
+    private boolean moved    = false;
+
+    /**
+     * Creates a brightness slider centred at (centreX, centreY).
+     *
+     * @param centreX      horizontal centre of the slider in world coordinates
+     * @param centreY      vertical centre of the slider in world coordinates
+     * @param trackWidth   pixel span of the full draggable range
+     * @param initialValue starting brightness level in [0.1, 1.0]
+     */
+    public BrightnessSlider(float centreX, float centreY, float trackWidth, float initialValue) {
+        this.trackLeft    = centreX - trackWidth / 2f;
+        this.trackCentreY = centreY;
+        this.trackWidth   = trackWidth;
+        this.knobRadius   = KNOB_RADIUS;
+        this.value        = clampBrightness(initialValue);
+
+        this.transform = new Transform2D(
+            trackLeft,
+            centreY - knobRadius,
+            trackWidth,
+            knobRadius * 2f
+        );
+    }
+
+    /**
+     * Polls cursor position and drag state using the provided cursor source.
+     * Call once per frame from the scene's update().
+     *
+     * @param cursor the world-space cursor source (Y-flip already applied)
+     */
+    public void updateInput(ICursorSource cursor) {
+        float mx    = cursor.getCursorX();
+        float my    = cursor.getCursorY();
+        float knobX = trackLeft + normalizedValue() * trackWidth;
+
+        moved = false;
+
+        if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
+            float dx        = mx - knobX;
+            float dy        = my - trackCentreY;
+            float hitRadius = knobRadius * 1.5f;
+            if (dx * dx + dy * dy <= hitRadius * hitRadius) {
+                dragging = true;
+            }
+        }
+
+        if (dragging && Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            float clampedTrackX = Math.max(trackLeft, Math.min(trackLeft + trackWidth, mx));
+            float normalized    = (clampedTrackX - trackLeft) / trackWidth;
+            value = clampBrightness(MIN_VALUE + normalized * VALUE_RANGE);
+            Settings.setBrightnessLevel(value);
+            moved = true;
+        }
+
+        if (!Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            dragging = false;
+        }
+    }
+
+    /**
+     * Returns the current brightness value.
+     *
+     * @return brightness level in [0.1, 1.0]
+     */
+    public float getValue() { return value; }
+
+    /**
+     * Returns true if the slider value changed this frame.
+     *
+     * @return true when a drag moved the knob since the last resetMoved() call
+     */
+    public boolean hasMoved() { return moved; }
+
+    /** Clears the moved flag — call after handling the value change. */
+    public void resetMoved() { moved = false; }
+
+    @Override public String     getAssetPath() { return null; }
+    @Override public ITransform getTransform() { return transform; }
+
+    /**
+     * Draws the track, filled portion, and knob.
+     *
+     * @param ctx the draw context for this frame
+     */
+    @Override
+    public void render(IDrawContext ctx) {
+        GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
+        float normalized = normalizedValue();
+        float knobX      = trackLeft + normalized * trackWidth;
+
+        gdxCtx.rect(COLOUR_TRACK,  trackLeft, trackCentreY - TRACK_HALF_H,
+                    trackWidth,              TRACK_HALF_H * 2f, true);
+        gdxCtx.rect(COLOUR_FILLED, trackLeft, trackCentreY - TRACK_HALF_H,
+                    normalized * trackWidth, TRACK_HALF_H * 2f, true);
+        gdxCtx.circle(dragging ? COLOUR_KNOB_DRAG : COLOUR_KNOB,
+                      knobX, trackCentreY, knobRadius, true);
+    }
+
+    /** No-op — this entity owns no GPU resources. */
+    public void dispose() { }
+
+    private float normalizedValue() {
+        return (value - MIN_VALUE) / VALUE_RANGE;
+    }
+
+    private float clampBrightness(float level) {
+        return Math.max(MIN_VALUE, Math.min(1.0f, level));
+    }
+}

--- a/core/src/main/java/com/p1_7/game/platform/GdxDrawContext.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxDrawContext.java
@@ -1,6 +1,7 @@
 package com.p1_7.game.platform;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -25,6 +26,7 @@ public class GdxDrawContext implements IDrawContext {
     private final SpriteBatch   batch;
     private final ShapeRenderer shapeRenderer;
     private final IAssetStore   assetStore;
+    private final Texture       solidPixel;
 
     private Pass                     currentPass      = Pass.NONE;
     private ShapeRenderer.ShapeType  activeShapeType  = null;
@@ -41,6 +43,7 @@ public class GdxDrawContext implements IDrawContext {
         this.batch         = batch.unwrap();
         this.shapeRenderer = shapeRenderer.unwrap();
         this.assetStore    = assetStore;
+        this.solidPixel    = createSolidPixel();
     }
 
     /**
@@ -56,6 +59,15 @@ public class GdxDrawContext implements IDrawContext {
         }
         currentPass     = Pass.NONE;
         activeShapeType = null;
+    }
+
+    /**
+     * releases resources owned directly by the draw context.
+     */
+    @Override
+    public void dispose() {
+        flush();
+        solidPixel.dispose();
     }
 
     /**
@@ -90,6 +102,20 @@ public class GdxDrawContext implements IDrawContext {
         batch.setColor(tint);
         batch.draw(texture, x, y, w, h);
         batch.setColor(Color.WHITE);
+    }
+
+    /**
+     * draws a tinted quad via SpriteBatch using an internal 1x1 white texture.
+     * this is the preferred path for translucent fullscreen overlays.
+     *
+     * @param color the tint and alpha to apply
+     * @param x     left edge in world coordinates
+     * @param y     bottom edge in world coordinates
+     * @param w     width
+     * @param h     height
+     */
+    public void drawTintedQuad(Color color, float x, float y, float w, float h) {
+        drawRawTexture(solidPixel, color, x, y, w, h);
     }
 
     /**
@@ -165,5 +191,14 @@ public class GdxDrawContext implements IDrawContext {
         shapeRenderer.begin(type);
         currentPass     = Pass.SHAPE;
         activeShapeType = type;
+    }
+
+    private Texture createSolidPixel() {
+        Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
+        pixmap.setColor(Color.WHITE);
+        pixmap.fill();
+        Texture texture = new Texture(pixmap);
+        pixmap.dispose();
+        return texture;
     }
 }

--- a/core/src/main/java/com/p1_7/game/platform/GdxRenderManager.java
+++ b/core/src/main/java/com/p1_7/game/platform/GdxRenderManager.java
@@ -17,7 +17,10 @@ public class GdxRenderManager extends RenderManager {
     public void render() {
         Gdx.gl.glClearColor(0f, 0f, 0f, 1f);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        Gdx.gl.glEnable(GL20.GL_BLEND);
+        Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
         super.render();
+        Gdx.gl.glDisable(GL20.GL_BLEND);
     }
 
     @Override

--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -17,6 +17,7 @@ import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
 import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.entities.MenuButton;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.platform.GdxDrawContext;
@@ -43,6 +44,7 @@ public class LevelCompleteScene extends Scene {
     private LabelText hintEsc;
     private MenuButton continueButton;
     private MenuButton mainMenuButton;
+    private BrightnessOverlay brightnessOverlay;
     private int currentLevel = 1;
     private float inputCooldown;
 
@@ -97,6 +99,7 @@ public class LevelCompleteScene extends Scene {
         mainMenuButton = MenuButton.withTexture("MAIN MENU", cx, cy - 85f, buttonFont, BTN_ASSET, HOVER_ASSET);
         hintSpace = new LabelText(spaceHint, cx, cy - 175f, promptFont);
         hintEsc = new LabelText("ESC - Main Menu", cx, cy - 220f, promptFont);
+        brightnessOverlay = new BrightnessOverlay();
 
         inputCooldown = INPUT_COOLDOWN_SECONDS;
     }
@@ -105,6 +108,7 @@ public class LevelCompleteScene extends Scene {
     public void onExit(SceneContext context) {
         if (continueButton != null) continueButton.dispose();
         if (mainMenuButton != null) mainMenuButton.dispose();
+        if (brightnessOverlay != null) brightnessOverlay.dispose();
         if (titleFont      != null) titleFont.dispose();
         if (promptFont     != null) promptFont.dispose();
         if (buttonFont     != null) buttonFont.dispose();
@@ -148,6 +152,7 @@ public class LevelCompleteScene extends Scene {
         renderQueue.queue(mainMenuButton);
         renderQueue.queue(hintSpace);
         renderQueue.queue(hintEsc);
+        renderQueue.queue(brightnessOverlay);
     }
 
     private boolean isLastLevel() {

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -18,6 +18,7 @@ import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
 import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.managers.IAudioManager;
 import com.p1_7.game.entities.MenuButton;
@@ -62,6 +63,7 @@ public class MenuScene extends Scene {
     private MenuButton     startButton;
     private MenuButton     settingsButton;
     private MenuButton     exitButton;
+    private BrightnessOverlay brightnessOverlay;
 
     public MenuScene() {
         this.name = "menu";
@@ -117,6 +119,7 @@ public class MenuScene extends Scene {
                         centreX, firstButtonY - BUTTON_SPACING,      buttonFont, BTN_ASSET, HOVER_ASSET);
         exitButton     = MenuButton.withTexture("EXIT",
                         centreX, firstButtonY - BUTTON_SPACING * 2f, buttonFont, BTN_ASSET, HOVER_ASSET);
+        brightnessOverlay = new BrightnessOverlay();
     }
 
     @Override
@@ -124,6 +127,7 @@ public class MenuScene extends Scene {
         if (startButton    != null) startButton.dispose();
         if (settingsButton != null) settingsButton.dispose();
         if (exitButton     != null) exitButton.dispose();
+        if (brightnessOverlay != null) brightnessOverlay.dispose();
         if (background  != null) background.dispose();
         if (titleFont   != null) titleFont.dispose();
         if (buttonFont  != null) buttonFont.dispose();
@@ -165,6 +169,7 @@ public class MenuScene extends Scene {
         renderQueue.queue(startButton);
         renderQueue.queue(settingsButton);
         renderQueue.queue(exitButton);
+        renderQueue.queue(brightnessOverlay);
     }
 
     // ── inner entities ────────────────────────────────────────────

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -18,6 +18,8 @@ import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
 import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.entities.BrightnessOverlay;
+import com.p1_7.game.entities.BrightnessSlider;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.managers.IAudioManager;
 import com.p1_7.game.entities.MenuButton;
@@ -62,7 +64,10 @@ public class SettingScene extends Scene {
     private LabelText          heading;
     private LabelText          volumeLabel;
     private VolumeSlider       volumeSlider;
+    private LabelText          brightnessLabel;
+    private BrightnessSlider   brightnessSlider;
     private MenuButton         backButton;
+    private BrightnessOverlay  brightnessOverlay;
 
     public SettingScene() {
         this.name = "settings";
@@ -110,17 +115,24 @@ public class SettingScene extends Scene {
         background  = new SettingsBackground(BG_ASSET);
         heading     = new LabelText("SETTINGS",   centreX, Settings.getWindowHeight() * 0.72f,
                                     headingFont);
-        volumeLabel = new LabelText(volumeText(audio), centreX, centreY + 60f,
+        volumeLabel = new LabelText(volumeText(audio), centreX, centreY + 110f,
                                     labelFont);
+        brightnessLabel = new LabelText(brightnessText(), centreX, centreY - 5f,
+                                        labelFont);
 
-        volumeSlider = new VolumeSlider(centreX, centreY - 10f, 340f, audio.getMusicVolume());
-        backButton   = MenuButton.withTexture("BACK", centreX, centreY - 120f, buttonFont, BTN_ASSET, HOVER_ASSET);
+        volumeSlider = new VolumeSlider(centreX, centreY + 40f, 340f, audio.getMusicVolume());
+        brightnessSlider = new BrightnessSlider(centreX, centreY - 75f, 340f,
+                                                Settings.getBrightnessLevel());
+        backButton   = MenuButton.withTexture("BACK", centreX, centreY - 190f, buttonFont, BTN_ASSET, HOVER_ASSET);
+        brightnessOverlay = new BrightnessOverlay();
     }
 
     @Override
     public void onExit(SceneContext context) {
         if (volumeSlider != null) volumeSlider.dispose();
+        if (brightnessSlider != null) brightnessSlider.dispose();
         if (backButton   != null) backButton.dispose();
+        if (brightnessOverlay != null) brightnessOverlay.dispose();
         if (background       != null) background.dispose();
         if (headingFont      != null) headingFont.dispose();
         if (labelFont        != null) labelFont.dispose();
@@ -139,12 +151,17 @@ public class SettingScene extends Scene {
 
         if (cursorSource == null) return;
         volumeSlider.updateInput(cursorSource);
+        brightnessSlider.updateInput(cursorSource);
         backButton.updateInput(cursorSource);
 
         if (volumeSlider.hasMoved()) {
             audio.setMusicVolume(volumeSlider.getValue());
             volumeLabel.setText(volumeText(audio));
             volumeSlider.resetMoved();
+        }
+        if (brightnessSlider.hasMoved()) {
+            brightnessLabel.setText(brightnessText());
+            brightnessSlider.resetMoved();
         }
         if (backButton.isClicked()) {
             backButton.resetClick();
@@ -158,11 +175,18 @@ public class SettingScene extends Scene {
         renderQueue.queue(heading);
         renderQueue.queue(volumeLabel);
         renderQueue.queue(volumeSlider);
+        renderQueue.queue(brightnessLabel);
+        renderQueue.queue(brightnessSlider);
         renderQueue.queue(backButton);
+        renderQueue.queue(brightnessOverlay);
     }
 
     private String volumeText(IAudioManager audio) {
         return "Music Volume:  " + Math.round(audio.getMusicVolume() * 100) + "%";
+    }
+
+    private String brightnessText() {
+        return "Brightness:  " + Math.round(Settings.getBrightnessLevel() * 100) + "%";
     }
 
     // ── inner entities ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `BrightnessSlider` and `BrightnessOverlay` entities, and wires brightness controls into `SettingScene`
- Applies brightness globally across the current scenes and routes the fullscreen dimming overlay through a batch-backed tinted-quad path instead of the previous fullscreen shape path
- Introduces draw-context resource disposal and updates `Settings` brightness defaults/clamping so brightness is stored as a screen-brightness value with default `0.9` and minimum `0.1`

## Test plan
- [x] `./gradlew core:compileJava`
- [x] `./gradlew lwjgl3:run` (launches without startup errors)
- [x] Visually verify brightness overlay behaviour in Menu, Settings, and Level Complete

Closes #43