### PR TITLE
refactor: extract shared background renderable

### DIFF
--- a/core/src/main/java/com/p1_7/game/entities/BackgroundImage.java
+++ b/core/src/main/java/com/p1_7/game/entities/BackgroundImage.java
@@ -1,7 +1,5 @@
-package com.p1_7.game.scenes.settings;
+package com.p1_7.game.entities;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Texture;
 import com.p1_7.abstractengine.render.IDrawContext;
 import com.p1_7.abstractengine.render.IRenderable;
 import com.p1_7.abstractengine.transform.ITransform;
@@ -9,17 +7,23 @@ import com.p1_7.game.Settings;
 import com.p1_7.game.core.Transform2D;
 import com.p1_7.game.platform.GdxDrawContext;
 
-final class SettingsBackground implements IRenderable {
+/**
+ * Shared full-screen background renderable that delegates texture ownership
+ * to the engine asset pipeline.
+ */
+public final class BackgroundImage implements IRenderable {
 
     private final Transform2D transform;
     private final String assetPath;
-    private final Texture texture;
 
-    SettingsBackground(String assetPath) {
+    public BackgroundImage(String assetPath) {
         this.assetPath = assetPath;
-        this.texture = new Texture(Gdx.files.internal(assetPath));
-        this.texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-        this.transform = new Transform2D(0f, 0f, Settings.getWindowWidth(), Settings.getWindowHeight());
+        this.transform = new Transform2D(
+            0f,
+            0f,
+            Settings.getWindowWidth(),
+            Settings.getWindowHeight()
+        );
     }
 
     @Override
@@ -38,11 +42,5 @@ final class SettingsBackground implements IRenderable {
         gdxCtx.drawTexture(assetPath,
             transform.getPosition(0), transform.getPosition(1),
             transform.getSize(0), transform.getSize(1));
-    }
-
-    void dispose() {
-        if (texture != null) {
-            texture.dispose();
-        }
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -8,20 +8,16 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFont
 import com.p1_7.abstractengine.input.IInputExtensionRegistry;
 import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.input.InputState;
-import com.p1_7.abstractengine.render.IDrawContext;
-import com.p1_7.abstractengine.render.IRenderable;
 import com.p1_7.abstractengine.render.IRenderQueue;
 import com.p1_7.abstractengine.scene.Scene;
 import com.p1_7.abstractengine.scene.SceneContext;
-import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
-import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.entities.LabelText;
 import com.p1_7.game.entities.MenuButton;
 import com.p1_7.game.input.GameActions;
 import com.p1_7.game.input.ICursorSource;
-import com.p1_7.game.platform.GdxDrawContext;
 
 public class LevelCompleteScene extends Scene {
 
@@ -39,7 +35,7 @@ public class LevelCompleteScene extends Scene {
     private BitmapFont titleFont;
     private BitmapFont promptFont;
     private BitmapFont buttonFont;
-    private Background background;
+    private BackgroundImage background;
     private LabelText title;
     private LabelText promptStatus;
     private LabelText hintSpace;
@@ -95,7 +91,7 @@ public class LevelCompleteScene extends Scene {
         int nextLevel = lastLevel ? 1 : currentLevel + 1;
         String continueLabel = lastLevel ? "PLAY AGAIN" : "CONTINUE";
         String spaceHint = lastLevel ? "SPACE - Play Again" : "SPACE - Continue";
-        background = new Background(BG_ASSET);
+        background = new BackgroundImage(BG_ASSET);
         title = new LabelText("LEVEL " + currentLevel + " COMPLETE!", cx, cy + 120f, titleFont);
         promptStatus = new LabelText("Next up: Level " + nextLevel, cx, cy + 55f, promptFont);
         continueButton = MenuButton.withTexture(continueLabel, cx, cy - 10f, buttonFont, BTN_ASSET, HOVER_ASSET);
@@ -166,26 +162,5 @@ public class LevelCompleteScene extends Scene {
 
     private boolean isLastLevel() {
         return currentLevel >= MAX_LEVEL;
-    }
-
-    private static class Background implements IRenderable {
-        private final Transform2D transform;
-        private final String assetPath;
-
-        Background(String assetPath) {
-            this.assetPath = assetPath;
-            this.transform = new Transform2D(0, 0, Settings.getWindowWidth(), Settings.getWindowHeight());
-        }
-
-        @Override public String     getAssetPath() { return assetPath; }
-        @Override public ITransform getTransform() { return transform; }
-
-        @Override
-        public void render(IDrawContext ctx) {
-            GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
-            gdxCtx.drawTexture(assetPath,
-                transform.getPosition(0), transform.getPosition(1),
-                transform.getSize(0),     transform.getSize(1));
-        }
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -2,7 +2,6 @@ package com.p1_7.game.scenes;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
@@ -19,6 +18,7 @@ import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
 import com.p1_7.game.core.Transform2D;
+import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.input.GameActions;
 import com.p1_7.game.input.ICursorSource;
@@ -61,7 +61,7 @@ public class MenuScene extends Scene {
     private IInputQuery inputQuery;
 
     // ── entities ─────────────────────────────────────────────────
-    private MenuBackground background;
+    private BackgroundImage background;
     private TitleText      titleText;
     private MenuButton     startButton;
     private MenuButton     settingsButton;
@@ -113,7 +113,7 @@ public class MenuScene extends Scene {
         generator.dispose();
 
         // ── entities ─────────────────────────────────────────────
-        background = new MenuBackground(BG_ASSET);
+        background = new BackgroundImage(BG_ASSET);
         titleText  = new TitleText("MATH QUEST MAZE", centreX,
                                    Settings.getWindowHeight() * 0.75f, titleFont);
 
@@ -132,7 +132,6 @@ public class MenuScene extends Scene {
         if (settingsButton != null) settingsButton.dispose();
         if (exitButton     != null) exitButton.dispose();
         if (brightnessOverlay != null) brightnessOverlay.dispose();
-        if (background  != null) background.dispose();
         if (titleFont   != null) titleFont.dispose();
         if (buttonFont  != null) buttonFont.dispose();
         inputQuery = null;
@@ -178,32 +177,6 @@ public class MenuScene extends Scene {
     }
 
     // ── inner entities ────────────────────────────────────────────
-
-    private static class MenuBackground implements IRenderable {
-        private final Transform2D transform;
-        private final String      assetPath;
-        private final Texture     texture;
-
-        MenuBackground(String assetPath) {
-            this.assetPath = assetPath;
-            this.texture   = new Texture(Gdx.files.internal(assetPath));
-            this.texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-            this.transform = new Transform2D(0, 0, Settings.getWindowWidth(), Settings.getWindowHeight());
-        }
-
-        @Override public String     getAssetPath() { return assetPath; }
-        @Override public ITransform getTransform() { return transform; }
-
-        @Override
-        public void render(IDrawContext ctx) {
-            GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
-            gdxCtx.drawTexture(assetPath,
-                transform.getPosition(0), transform.getPosition(1),
-                transform.getSize(0),     transform.getSize(1));
-        }
-
-        void dispose() { if (texture != null) texture.dispose(); }
-    }
 
     private static class TitleText extends Entity implements IRenderable {
         private final Transform2D transform;

--- a/core/src/main/java/com/p1_7/game/scenes/settings/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/settings/SettingScene.java
@@ -20,6 +20,7 @@ import com.p1_7.abstractengine.render.IRenderQueue;
 import com.p1_7.abstractengine.scene.Scene;
 import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.game.Settings;
+import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.entities.BrightnessSlider;
 import com.p1_7.game.entities.LabelText;
@@ -67,7 +68,7 @@ public class SettingScene extends Scene {
 
     private IAudioManager audio;
 
-    private SettingsBackground background;
+    private BackgroundImage background;
     private LabelText heading;
     private LabelText volumeLabel;
     private VolumeSlider volumeSlider;
@@ -208,7 +209,7 @@ public class SettingScene extends Scene {
         float volumeLabelY = volumeSliderY + 50f;
         float headingY = volumeLabelY + 66f;
 
-        background = new SettingsBackground(BG_ASSET);
+        background = new BackgroundImage(BG_ASSET);
         heading = createCenteredLabel("SETTINGS", headingY, headingFont);
         volumeLabel = createCenteredLabel(volumeText(), volumeLabelY, labelFont);
         brightnessLabel = createCenteredLabel(brightnessText(), brightnessLabelY, labelFont);
@@ -263,10 +264,6 @@ public class SettingScene extends Scene {
         if (brightnessOverlay != null) {
             brightnessOverlay.dispose();
         }
-        if (background != null) {
-            background.dispose();
-        }
-
         background = null;
         heading = null;
         volumeLabel = null;


### PR DESCRIPTION
## Summary
- extract a shared `BackgroundImage` renderable for menu-oriented scenes
- replace the scene-local background implementations in MenuScene, LevelCompleteScene, and SettingScene
- remove background-specific disposal now that rendering goes through the shared asset pipeline

## Verification
- `./gradlew core:compileJava`

Addresses #25