### PR TITLE
refactor: consolidate shared text renderable

### DIFF
--- a/core/src/main/java/com/p1_7/game/entities/Text.java
+++ b/core/src/main/java/com/p1_7/game/entities/Text.java
@@ -10,15 +10,15 @@ import com.p1_7.game.core.Transform2D;
 import com.p1_7.game.platform.GdxDrawContext;
 
 /**
- * Reusable centered text entity for scene UI labels.
+ * Reusable centered text renderable for game and scene text.
  */
-public class LabelText extends Entity implements IRenderable {
+public class Text extends Entity implements IRenderable {
 
     private final Transform2D transform;
     private final BitmapFont font;
     private String text;
 
-    public LabelText(String text, float centreX, float centreY, BitmapFont font) {
+    public Text(String text, float centreX, float centreY, BitmapFont font) {
         this.text = text;
         this.font = font;
         this.transform = new Transform2D(centreX, centreY, 0f, 0f);

--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -14,8 +14,8 @@ import com.p1_7.abstractengine.scene.SceneContext;
 import com.p1_7.game.Settings;
 import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
-import com.p1_7.game.entities.LabelText;
 import com.p1_7.game.entities.MenuButton;
+import com.p1_7.game.entities.Text;
 import com.p1_7.game.input.GameActions;
 import com.p1_7.game.input.ICursorSource;
 
@@ -36,10 +36,10 @@ public class LevelCompleteScene extends Scene {
     private BitmapFont promptFont;
     private BitmapFont buttonFont;
     private BackgroundImage background;
-    private LabelText title;
-    private LabelText promptStatus;
-    private LabelText hintSpace;
-    private LabelText hintEsc;
+    private Text title;
+    private Text promptStatus;
+    private Text hintSpace;
+    private Text hintEsc;
     private MenuButton continueButton;
     private MenuButton mainMenuButton;
     private BrightnessOverlay brightnessOverlay;
@@ -92,12 +92,12 @@ public class LevelCompleteScene extends Scene {
         String continueLabel = lastLevel ? "PLAY AGAIN" : "CONTINUE";
         String spaceHint = lastLevel ? "SPACE - Play Again" : "SPACE - Continue";
         background = new BackgroundImage(BG_ASSET);
-        title = new LabelText("LEVEL " + currentLevel + " COMPLETE!", cx, cy + 120f, titleFont);
-        promptStatus = new LabelText("Next up: Level " + nextLevel, cx, cy + 55f, promptFont);
+        title = new Text("LEVEL " + currentLevel + " COMPLETE!", cx, cy + 120f, titleFont);
+        promptStatus = new Text("Next up: Level " + nextLevel, cx, cy + 55f, promptFont);
         continueButton = MenuButton.withTexture(continueLabel, cx, cy - 10f, buttonFont, BTN_ASSET, HOVER_ASSET);
         mainMenuButton = MenuButton.withTexture("MAIN MENU", cx, cy - 85f, buttonFont, BTN_ASSET, HOVER_ASSET);
-        hintSpace = new LabelText(spaceHint, cx, cy - 175f, promptFont);
-        hintEsc = new LabelText("ESC - Main Menu", cx, cy - 220f, promptFont);
+        hintSpace = new Text(spaceHint, cx, cy - 175f, promptFont);
+        hintEsc = new Text("ESC - Main Menu", cx, cy - 220f, promptFont);
         brightnessOverlay = new BrightnessOverlay();
 
         inputCooldown = INPUT_COOLDOWN_SECONDS;

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -3,28 +3,22 @@ package com.p1_7.game.scenes;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFontParameter;
-import com.p1_7.abstractengine.entity.Entity;
 import com.p1_7.abstractengine.input.IInputExtensionRegistry;
 import com.p1_7.abstractengine.input.IInputQuery;
 import com.p1_7.abstractengine.input.InputState;
-import com.p1_7.abstractengine.render.IDrawContext;
-import com.p1_7.abstractengine.render.IRenderable;
 import com.p1_7.abstractengine.render.IRenderQueue;
 import com.p1_7.abstractengine.scene.Scene;
 import com.p1_7.abstractengine.scene.SceneContext;
-import com.p1_7.abstractengine.transform.ITransform;
 import com.p1_7.game.Settings;
-import com.p1_7.game.core.Transform2D;
 import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
+import com.p1_7.game.entities.Text;
 import com.p1_7.game.input.GameActions;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.managers.IAudioManager;
 import com.p1_7.game.entities.MenuButton;
-import com.p1_7.game.platform.GdxDrawContext;
 
 /**
  * Main menu scene for Math Quest Maze.
@@ -62,7 +56,7 @@ public class MenuScene extends Scene {
 
     // ── entities ─────────────────────────────────────────────────
     private BackgroundImage background;
-    private TitleText      titleText;
+    private Text           titleText;
     private MenuButton     startButton;
     private MenuButton     settingsButton;
     private MenuButton     exitButton;
@@ -114,7 +108,7 @@ public class MenuScene extends Scene {
 
         // ── entities ─────────────────────────────────────────────
         background = new BackgroundImage(BG_ASSET);
-        titleText  = new TitleText("MATH QUEST MAZE", centreX,
+        titleText  = new Text("MATH QUEST MAZE", centreX,
                                    Settings.getWindowHeight() * 0.75f, titleFont);
 
         startButton    = MenuButton.withTexture("START",
@@ -174,31 +168,5 @@ public class MenuScene extends Scene {
         renderQueue.queue(settingsButton);
         renderQueue.queue(exitButton);
         renderQueue.queue(brightnessOverlay);
-    }
-
-    // ── inner entities ────────────────────────────────────────────
-
-    private static class TitleText extends Entity implements IRenderable {
-        private final Transform2D transform;
-        private final BitmapFont  font;
-        private final String      text;
-
-        TitleText(String text, float cx, float cy, BitmapFont font) {
-            this.text      = text;
-            this.font      = font;
-            this.transform = new Transform2D(cx, cy, 0f, 0f);
-        }
-
-        @Override public String     getAssetPath() { return null; }
-        @Override public ITransform getTransform() { return transform; }
-
-        @Override
-        public void render(IDrawContext ctx) {
-            GdxDrawContext gdxCtx = (GdxDrawContext) ctx;
-            GlyphLayout layout = new GlyphLayout(font, text);
-            gdxCtx.drawFont(font, text,
-                transform.getPosition(0) - layout.width  / 2f,
-                transform.getPosition(1) + layout.height / 2f);
-        }
     }
 }

--- a/core/src/main/java/com/p1_7/game/scenes/settings/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/settings/SettingScene.java
@@ -23,8 +23,8 @@ import com.p1_7.game.Settings;
 import com.p1_7.game.entities.BackgroundImage;
 import com.p1_7.game.entities.BrightnessOverlay;
 import com.p1_7.game.entities.BrightnessSlider;
-import com.p1_7.game.entities.LabelText;
 import com.p1_7.game.entities.MenuButton;
+import com.p1_7.game.entities.Text;
 import com.p1_7.game.input.GameActions;
 import com.p1_7.game.input.ICursorSource;
 import com.p1_7.game.managers.IAudioManager;
@@ -69,16 +69,16 @@ public class SettingScene extends Scene {
     private IAudioManager audio;
 
     private BackgroundImage background;
-    private LabelText heading;
-    private LabelText volumeLabel;
+    private Text heading;
+    private Text volumeLabel;
     private VolumeSlider volumeSlider;
-    private LabelText brightnessLabel;
+    private Text brightnessLabel;
     private BrightnessSlider brightnessSlider;
-    private LabelText controlsHeading;
-    private LabelText remapHint;
-    private LabelText actionHeader;
-    private LabelText primaryHeader;
-    private LabelText alternateHeader;
+    private Text controlsHeading;
+    private Text remapHint;
+    private Text actionHeader;
+    private Text primaryHeader;
+    private Text alternateHeader;
     private MenuButton backButton;
     private BrightnessOverlay brightnessOverlay;
     private final List<RemapSlot> remapSlots = new ArrayList<>();
@@ -224,21 +224,21 @@ public class SettingScene extends Scene {
         buildRemapSlots(firstRowY, rowSpacing);
     }
 
-    private LabelText createCenteredLabel(String text, float centreYPosition, BitmapFont font) {
-        return new LabelText(text, centreX, centreYPosition, font);
+    private Text createCenteredLabel(String text, float centreYPosition, BitmapFont font) {
+        return new Text(text, centreX, centreYPosition, font);
     }
 
     private void createRemapHeaders(float tableHeaderY) {
         float tableLeft = centreX - RemapSlot.TABLE_WIDTH / 2f;
-        actionHeader = new LabelText("ACTION",
+        actionHeader = new Text("ACTION",
             tableLeft + RemapSlot.ACTION_COLUMN_WIDTH / 2f,
             tableHeaderY,
             tableFont);
-        primaryHeader = new LabelText("PRIMARY",
+        primaryHeader = new Text("PRIMARY",
             tableLeft + RemapSlot.ACTION_COLUMN_WIDTH + RemapSlot.CELL_GAP + RemapSlot.KEY_COLUMN_WIDTH / 2f,
             tableHeaderY,
             tableFont);
-        alternateHeader = new LabelText("ALTERNATE",
+        alternateHeader = new Text("ALTERNATE",
             tableLeft + RemapSlot.ACTION_COLUMN_WIDTH + RemapSlot.CELL_GAP * 2f
                 + RemapSlot.KEY_COLUMN_WIDTH * 1.5f,
             tableHeaderY,


### PR DESCRIPTION
## Summary
- rename the shared centered text renderable from `LabelText` to `Text`
- replace `MenuScene`'s private `TitleText` implementation with the shared `Text` class
- update existing scene usages to the new shared text type

## Verification
- `./gradlew core:compileJava`

Part of #25