### PR TITLE
feat: add Difficulty enum and QuestionGenerator

### DIFF
--- a/core/src/main/java/com/p1_7/game/gameplay/Difficulty.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/Difficulty.java
@@ -30,6 +30,10 @@ public enum Difficulty {
      * @param maxOperand the inclusive upper bound for operands
      */
     Difficulty(int minOperand, int maxOperand) {
+        if (minOperand > maxOperand) {
+            throw new IllegalArgumentException(
+                "minOperand (" + minOperand + ") must be <= maxOperand (" + maxOperand + ")");
+        }
         this.minOperand = minOperand;
         this.maxOperand = maxOperand;
     }

--- a/core/src/main/java/com/p1_7/game/gameplay/QuestionGenerator.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/QuestionGenerator.java
@@ -22,17 +22,34 @@ public class QuestionGenerator {
     private final Random random;
 
     /**
-     * constructs a question generator for the given difficulty level.
+     * constructs a question generator for the given difficulty level using an unseeded random source.
      *
      * @param difficulty the difficulty that controls operand range; must not be null
      * @throws IllegalArgumentException if difficulty is null
      */
     public QuestionGenerator(Difficulty difficulty) {
+        this(difficulty, new Random());
+    }
+
+    /**
+     * constructs a question generator with an explicit random source.
+     *
+     * prefer this overload in tests: passing a seeded random instance makes generation
+     * deterministic, allowing specific behaviours (e.g. operand swapping) to be asserted reliably.
+     *
+     * @param difficulty the difficulty that controls operand range; must not be null
+     * @param random     the random source to use for all generation decisions; must not be null
+     * @throws IllegalArgumentException if difficulty or random is null
+     */
+    public QuestionGenerator(Difficulty difficulty, Random random) {
         if (difficulty == null) {
             throw new IllegalArgumentException("difficulty must not be null");
         }
+        if (random == null) {
+            throw new IllegalArgumentException("random must not be null");
+        }
         this.difficulty = difficulty;
-        this.random = new Random();
+        this.random = random;
     }
 
     /**
@@ -108,6 +125,13 @@ public class QuestionGenerator {
             }
 
             options.add(candidate);
+        }
+
+        // guard against an exhausted offset pool producing fewer than 4 options
+        if (options.size() != 4) {
+            throw new IllegalStateException(
+                "buildOptions failed to produce 4 unique non-negative distractors for correctAnswer="
+                    + correctAnswer + "; only produced " + options.size());
         }
 
         // shuffle so the correct answer does not always appear at index 0


### PR DESCRIPTION
## Summary
- Adds `Difficulty` enum mapping each level (EASY, MEDIUM, HARD) to an inclusive operand range, making difficulty a first-class concept rather than a raw integer
- Adds `QuestionGenerator`, a stateful class that produces `MathQuestion` instances by randomly selecting an operation, drawing operands from the difficulty's range, and building a shuffled 4-option list with plausible distractors

## Test plan
- [ ] `Difficulty.EASY` returns min=1, max=10; `MEDIUM` returns min=1, max=20; `HARD` returns min=1, max=100
- [ ] `new QuestionGenerator(null)` throws `IllegalArgumentException`
- [ ] `generateQuestion()` returns a `MathQuestion` with exactly 4 unique options containing the correct answer
- [ ] Subtraction results are never negative
- [ ] Prompt format matches `"a + b = ?"` or `"a - b = ?"`
- [ ] No libGDX or scene imports in either file

Closes #94 