### PR TITLE
feat: add RoomAssignment, RoomAssigner, and LevelOrchestrator scaffold

### DIFF
--- a/core/src/main/java/com/p1_7/game/gameplay/ILevelOrchestrator.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/ILevelOrchestrator.java
@@ -16,6 +16,7 @@ public interface ILevelOrchestrator {
      * must be called before any other method on this interface.
      *
      * @param difficulty the difficulty level to use for question generation; must not be null
+     * @throws IllegalArgumentException if difficulty is null
      */
     void startLevel(Difficulty difficulty);
 

--- a/core/src/main/java/com/p1_7/game/gameplay/LevelOrchestrator.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/LevelOrchestrator.java
@@ -24,14 +24,30 @@ public class LevelOrchestrator implements ILevelOrchestrator {
      * call startLevel before using any other method.
      */
     public LevelOrchestrator() {
-        this.roomAssigner = new RoomAssigner();
+        this(new RoomAssigner());
     }
 
     /**
-     * {@inheritDoc}
+     * constructs a level orchestrator with the given room assigner.
      *
+     * package-private to allow injection in unit tests without exposing the
+     * dependency publicly.
+     *
+     * @param roomAssigner the room assigner to use; must not be null
+     * @throws IllegalArgumentException if roomAssigner is null
+     */
+    LevelOrchestrator(RoomAssigner roomAssigner) {
+        if (roomAssigner == null) {
+            throw new IllegalArgumentException("roomAssigner must not be null");
+        }
+        this.roomAssigner = roomAssigner;
+    }
+
+    /**
      * creates a new QuestionGenerator and GameRound for the given difficulty, then
-     * refreshes the room assignment to match the first question.
+     * refreshes the room assignment to match the first question. if called while a
+     * round is already active, the previous round's score, health, and phase are
+     * discarded and a new round begins immediately.
      *
      * @param difficulty the difficulty level for this session; must not be null
      * @throws IllegalArgumentException if difficulty is null
@@ -47,66 +63,36 @@ public class LevelOrchestrator implements ILevelOrchestrator {
         refreshAssignment();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public RoundPhase getPhase() {
         requireActiveRound();
         return gameRound.getPhase();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public MathQuestion getCurrentQuestion() {
         requireActiveRound();
         return gameRound.getCurrentQuestion();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public RoomAssignment getRoomAssignment() {
         requireActiveRound();
         return roomAssignment;
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public int getScore() {
         requireActiveRound();
         return gameRound.getScore();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public int getHealth() {
         requireActiveRound();
         return gameRound.getHealth();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws IllegalStateException if startLevel has not been called
-     */
     @Override
     public boolean isLastAnswerCorrect() {
         requireActiveRound();
@@ -114,8 +100,6 @@ public class LevelOrchestrator implements ILevelOrchestrator {
     }
 
     /**
-     * {@inheritDoc}
-     *
      * resolves the answer for the given room index from the current assignment and
      * delegates to GameRound.submitAnswer.
      *
@@ -133,8 +117,6 @@ public class LevelOrchestrator implements ILevelOrchestrator {
     }
 
     /**
-     * {@inheritDoc}
-     *
      * captures the phase before delegating so the assignment can be refreshed when
      * advancing out of ROUND_RESET, which is the transition that loads a new question.
      *

--- a/core/src/main/java/com/p1_7/game/gameplay/RoomAssigner.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/RoomAssigner.java
@@ -14,13 +14,6 @@ import java.util.Map;
 public class RoomAssigner {
 
     /**
-     * constructs a new room assigner.
-     */
-    public RoomAssigner() {
-        // stateless — no initialisation required
-    }
-
-    /**
      * assigns the four answer options from the given question to room indices 0–3.
      *
      * the i-th option in the question's options list is assigned to room index i.
@@ -38,6 +31,11 @@ public class RoomAssigner {
         }
 
         List<Integer> options = question.getOptions();
+        if (options.size() != 4) {
+            throw new IllegalArgumentException(
+                "question must have exactly 4 options, got: " + options.size());
+        }
+
         Map<Integer, Integer> roomToAnswer = new HashMap<>();
 
         // zip options with indices 0–3 directly; options are already shuffled by the generator

--- a/core/src/main/java/com/p1_7/game/gameplay/RoomAssignment.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/RoomAssignment.java
@@ -47,10 +47,11 @@ public class RoomAssignment {
      * @throws IllegalArgumentException if roomIndex is not in the range 0–3
      */
     public int getAnswerForRoom(int roomIndex) {
-        if (!roomToAnswer.containsKey(roomIndex)) {
+        Integer answer = roomToAnswer.get(roomIndex);
+        if (answer == null) {
             throw new IllegalArgumentException(
                 "roomIndex must be in [0, 3], got: " + roomIndex);
         }
-        return roomToAnswer.get(roomIndex);
+        return answer;
     }
 }


### PR DESCRIPTION
## Summary

- Adds `RoomAssignment`, an immutable value object mapping room indices 0–3 to answer values
- Adds `RoomAssigner`, a stateless factory that zips `MathQuestion.getOptions()` with indices to produce a `RoomAssignment`
- Adds `ILevelOrchestrator`, a facade interface `GameScene` will depend on
- Adds `LevelOrchestrator`, the concrete implementation coordinating `GameRound` and `RoomAssignment`

All four classes live in `com.p1_7.game.gameplay` with no GDX or external dependencies.

## Test plan

- [x] `./gradlew :core:compileJava` exits 0 with no errors
- [ ] `RoomAssignment` throws `IllegalArgumentException` for indices outside 0–3
- [ ] `LevelOrchestrator` methods throw `IllegalStateException` before `startLevel` is called
- [ ] `advance()` from `ROUND_RESET` refreshes the room assignment; other transitions do not
- [ ] `submitRoomChoice` correctly resolves the answer via `RoomAssignment` before delegating to `GameRound`

Closes #103