### PR TITLE
feat: Player entity with wall collision and GameScene wiring

### DIFF
--- a/core/src/main/java/com/p1_7/game/gameplay/Player.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/Player.java
@@ -158,10 +158,8 @@ public class Player extends Entity implements IRenderable, IMovable {
      */
     public void update(float deltaTime, IInputQuery inputQuery, RoundPhase phase,
                        MazeLayout layout) {
-        // lock movement during non-interactive phases
-        if (phase == RoundPhase.QUESTION_INTRO
-                || phase == RoundPhase.FEEDBACK
-                || phase == RoundPhase.ROUND_RESET) {
+        // only allow movement during the choosing phase; any other phase locks the player
+        if (phase != RoundPhase.CHOOSING) {
             setVelocity(new float[]{ 0f, 0f });
             return;
         }
@@ -175,20 +173,20 @@ public class Player extends Entity implements IRenderable, IMovable {
         float x = transform.getPosition(0);
         float y = transform.getPosition(1);
 
-        // axis-separated AABB wall check — zero out whichever axis would cause penetration
+        // two-pass axis-separated AABB wall check — each axis is resolved independently so
+        // one wall zeroing x cannot influence the y test for a different wall in the same frame
         for (float[] wall : layout.getWallBounds()) {
-            float wx = wall[0];
-            float wy = wall[1];
-            float ww = wall[2];
-            float wh = wall[3];
-
-            // test x-axis movement independently
-            if (overlaps(x + rawVx * deltaTime, y, SIZE, SIZE, wx, wy, ww, wh)) {
+            if (overlaps(x + rawVx * deltaTime, y, SIZE, SIZE,
+                         wall[0], wall[1], wall[2], wall[3])) {
                 rawVx = 0f;
+                break;
             }
-            // test y-axis movement independently
-            if (overlaps(x, y + rawVy * deltaTime, SIZE, SIZE, wx, wy, ww, wh)) {
+        }
+        for (float[] wall : layout.getWallBounds()) {
+            if (overlaps(x, y + rawVy * deltaTime, SIZE, SIZE,
+                         wall[0], wall[1], wall[2], wall[3])) {
                 rawVy = 0f;
+                break;
             }
         }
 

--- a/core/src/main/java/com/p1_7/game/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameScene.java
@@ -41,8 +41,8 @@ public class GameScene extends Scene {
      */
     @Override
     public void onEnter(SceneContext context) {
-        float[] spawn = MazeLayout.createDefault().getSpawnPoint();
         this.layout     = MazeLayout.createDefault();
+        float[] spawn   = layout.getSpawnPoint();
         this.player     = new Player(spawn[0], spawn[1]);
         this.inputQuery = context.get(IInputQuery.class);
     }


### PR DESCRIPTION
## Summary
- Adds `Player` entity (`Entity` + `IRenderable` + `IMovable`) with a cyan 32×32 shape render
- `update()` reads WASD/arrow input, locks movement during non-interactive phases, and performs axis-separated AABB wall collision against `MazeLayout.getWallBounds()`
- `move()` integrates velocity into position (will be delegated to `MovementManager` in #112)
- `resetToSpawn()` recentres the player on a given spawn coordinate
- `GameScene` wired with `MazeLayout`, `Player`, and `IInputQuery`; phase hardcoded to `CHOOSING` until `GameRound` lands in #100

## Test plan
- [x] `./gradlew :core:compileJava` passes with no errors
- [ ] Launch game, reach the game scene — cyan square visible at screen centre
- [ ] Player moves with WASD / arrow keys and is blocked by the four outer walls
- [ ] `new Player(640, 360).getTransform().getPosition(0)` returns `624.0`
- [ ] `getVelocity()` returns `[0, 0]` after construction
- [ ] Calling `update()` with `RoundPhase.QUESTION_INTRO` leaves velocity at `[0, 0]`

Closes #97