### PR TITLE
feat: HUD and overlays for answer rooms and phase feedback

### DIFF
--- a/core/src/main/java/com/p1_7/game/entities/QuestionPanel.java
+++ b/core/src/main/java/com/p1_7/game/entities/QuestionPanel.java
@@ -37,8 +37,8 @@ public class QuestionPanel extends Entity implements IRenderable {
     /** duration of the slide animation in seconds; must match PHASE_HOLD_SECONDS in GameScene */
     private static final float ANIM_DURATION = 1.0f;
 
-    /** semi-transparent dark background colour */
-    private static final Color PANEL_BG = new Color(0.1f, 0.1f, 0.1f, 0.85f);
+    /** deep navy background — matches the steel-blue dungeon palette */
+    private static final Color PANEL_BG = new Color(0.04f, 0.07f, 0.14f, 0.92f);
 
     /** transform used to satisfy ITransformable; y-axis is kept in sync with currentY */
     private final Transform2D transform;

--- a/core/src/main/java/com/p1_7/game/gameplay/Player.java
+++ b/core/src/main/java/com/p1_7/game/gameplay/Player.java
@@ -15,7 +15,7 @@ import com.p1_7.game.input.GameActions;
 import com.p1_7.game.platform.GdxDrawContext;
 
 /**
- * the player entity — a cyan square that moves freely around the maze.
+ * the player entity — a sky-cyan square that moves freely around the maze.
  *
  * movement is locked during non-interactive phases (QUESTION_INTRO, FEEDBACK,
  * ROUND_RESET). wall collision is handled reactively by MazeCollisionManager,
@@ -30,6 +30,9 @@ public class Player extends Entity implements IRenderable, IMovable, ICollidable
 
     /** movement speed in pixels per second */
     private static final float SPEED = 200f;
+
+    /** player fill colour — sky cyan, distinct against the dark background */
+    private static final Color PLAYER_COLOUR = new Color(0.30f, 0.82f, 0.98f, 1f);
 
     /** player width and height in pixels */
     private static final float SIZE = 32f;
@@ -86,14 +89,14 @@ public class Player extends Entity implements IRenderable, IMovable, ICollidable
     }
 
     /**
-     * draws the player as a solid cyan rectangle.
+     * draws the player as a solid sky-cyan rectangle.
      *
      * @param ctx the draw context for this frame
      */
     @Override
     public void render(IDrawContext ctx) {
         GdxDrawContext gdx = (GdxDrawContext) ctx;
-        gdx.rect(Color.CYAN,
+        gdx.rect(PLAYER_COLOUR,
                  transform.getPosition(0),
                  transform.getPosition(1),
                  SIZE, SIZE, true);

--- a/core/src/main/java/com/p1_7/game/managers/FontManager.java
+++ b/core/src/main/java/com/p1_7/game/managers/FontManager.java
@@ -71,6 +71,25 @@ public class FontManager extends Manager implements IFontManager {
             new Color(1f, 1f, 1f, 0.35f));
     }
 
+    /**
+     * returns a cool off-white bitmap font suitable for rendering on dark backgrounds,
+     * such as the game scene HUD and answer-room labels.
+     *
+     * @param size point size of the generated font
+     * @return cached bitmap font in cool off-white with a faint dark drop shadow
+     */
+    @Override
+    public BitmapFont getLightTextFont(int size) {
+        return getOrCreate("light-text:" + size,
+            size,
+            // cool off-white — readable on the near-black game scene background
+            new Color(0.88f, 0.92f, 1f, 1f),
+            1,
+            -1,
+            // faint dark shadow to lift the text off any mid-tone surface
+            new Color(0f, 0f, 0f, 0.55f));
+    }
+
     private BitmapFont getOrCreate(String key, int size, Color color,
                                    int shadowOffsetX, int shadowOffsetY, Color shadowColor) {
         BitmapFont cached = fontCache.get(key);

--- a/core/src/main/java/com/p1_7/game/managers/IFontManager.java
+++ b/core/src/main/java/com/p1_7/game/managers/IFontManager.java
@@ -12,4 +12,6 @@ public interface IFontManager {
     BitmapFont getDarkTextFont(int size);
 
     BitmapFont getPromptFont();
+
+    BitmapFont getLightTextFont(int size);
 }

--- a/core/src/main/java/com/p1_7/game/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameScene.java
@@ -53,9 +53,15 @@ public class GameScene extends Scene {
     private static final float FEEDBACK_HOLD_SECONDS = 2.0f;
 
     /** pre-allocated overlay colours — reused every frame to avoid per-frame allocation */
-    private static final Color OVERLAY_CORRECT    = new Color(0f, 0.7f, 0f, 0.35f);
-    private static final Color OVERLAY_WRONG      = new Color(0.8f, 0f, 0f, 0.35f);
-    private static final Color HEALTH_LOST_COLOUR = new Color(0.3f, 0.3f, 0.3f, 1f);
+    private static final Color OVERLAY_CORRECT    = new Color(0.08f, 0.62f, 0.22f, 0.42f);
+    private static final Color OVERLAY_WRONG      = new Color(0.75f, 0.08f, 0.08f, 0.42f);
+
+    /** room outline colour — steel blue, visible against the black background */
+    private static final Color ROOM_OUTLINE_COLOUR = new Color(0.30f, 0.45f, 0.62f, 1f);
+
+    /** health pip colours — warm red for remaining health, dark steel-blue for lost */
+    private static final Color HEALTH_ACTIVE_COLOUR = new Color(0.90f, 0.20f, 0.20f, 1f);
+    private static final Color HEALTH_LOST_COLOUR   = new Color(0.18f, 0.22f, 0.28f, 1f);
 
     /** the fixed spatial layout providing spawn point, room bounds, and wall bounds */
     private MazeLayout layout;
@@ -176,8 +182,8 @@ public class GameScene extends Scene {
 
         // source fonts from the font manager
         IFontManager fontManager = context.get(IFontManager.class);
-        this.promptFont = fontManager.getPromptFont();
-        this.hudFont    = fontManager.getDarkTextFont(22);
+        this.promptFont = fontManager.getLightTextFont(28);
+        this.hudFont    = fontManager.getLightTextFont(22);
 
         // allocate per-room answer caches before the loop so closures can capture the array references
         this.roomAnswerTexts   = new String[4];
@@ -210,8 +216,8 @@ public class GameScene extends Scene {
                 @Override
                 public void render(IDrawContext ctx) {
                     GdxDrawContext gdx = (GdxDrawContext) ctx;
-                    // grey outline marking the room boundary
-                    gdx.rect(Color.GRAY, rect[0], rect[1], rect[2], rect[3], false);
+                    // steel-blue outline marking the room boundary
+                    gdx.rect(ROOM_OUTLINE_COLOUR, rect[0], rect[1], rect[2], rect[3], false);
                     // layout and text were pre-computed in refreshRoomAnswerCache — no allocation
                     GlyphLayout gl = capturedAnswerLayouts[roomIndex];
                     gdx.drawFont(roomFont, capturedAnswerTexts[roomIndex],
@@ -289,7 +295,7 @@ public class GameScene extends Scene {
                 for (int i = 0; i < 3; i++) {
                     float x = BASE_X + i * (SQ + GAP);
                     if (i < health) {
-                        gdx.rect(Color.RED, x, BASE_Y, SQ, SQ, true);
+                        gdx.rect(HEALTH_ACTIVE_COLOUR, x, BASE_Y, SQ, SQ, true);
                     } else {
                         // reuse static constant — no allocation
                         gdx.rect(HEALTH_LOST_COLOUR, x, BASE_Y, SQ, SQ, false);


### PR DESCRIPTION
## Summary

- Adds answer-room HUD overlays showing the candidate answer in each room, with steel-blue outlines
- Adds a `QuestionPanel` entity that slides in from screen centre during `QUESTION_INTRO`
- Adds a full-screen feedback overlay (green/red tint + result text) during `FEEDBACK`
- Adds score and health displays in the top corners
- Fixes `phaseHoldTimer` not being initialised on scene entry, which caused `QUESTION_INTRO` to be skipped entirely
- Applies a cohesive steel-blue dungeon colour palette (room outlines, player, panel background, HUD text)

## Test plan

- [x] On scene entry, `QuestionPanel` slides from screen centre to the bottom over ~1 second
- [x] After ~1 second the scene transitions to `CHOOSING` and the player can move
- [x] Entering the correct answer room triggers a green overlay with "CORRECT!" text
- [x] Entering a wrong answer room triggers a red overlay with "WRONG!" text and decrements health
- [x] Score increments correctly on correct answers
- [x] Health pips display correctly (warm red = remaining, dark steel-blue = lost)
- [x] Subsequent `QUESTION_INTRO` phases after correct answers also animate correctly

Closes #99