### PR TITLE
fix: resolve scene services from context per-hook instead of caching in onEnter

### DIFF
--- a/core/src/main/java/com/p1_7/game/scenes/GameOverScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameOverScene.java
@@ -29,10 +29,6 @@ public class GameOverScene extends Scene {
     private static final String BTN_ASSET = "menu/button.png";
     private static final String HOVER_ASSET = "menu/button_hover.png";
 
-    // ── input ──────────────────────────────────────────────────────────────────
-    private ICursorSource cursorSource;
-    private IInputQuery inputQuery;
-
     // ── ui elements ────────────────────────────────────────────────────────────
     private BitmapFont titleFont;
     private BitmapFont promptFont;
@@ -63,13 +59,6 @@ public class GameOverScene extends Scene {
         titleFont = fontManager.getGoldDisplayFont(54);
         promptFont = fontManager.getPromptFont();
         buttonFont = fontManager.getDarkTextFont(22);
-
-        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        inputQuery = context.get(IInputQuery.class);
-        if (inputRegistry.hasExtension(ICursorSource.class)) {
-            cursorSource = inputRegistry.getExtension(ICursorSource.class);
-        }
-        // cursorSource stays null if not registered; update() guard handles it cleanly
 
         float cx = Settings.getWindowWidth() / 2f;
         float cy = Settings.getWindowHeight() / 2f;
@@ -103,11 +92,9 @@ public class GameOverScene extends Scene {
         retryButton    = null;
         mainMenuButton = null;
         brightnessOverlay = null;
-        titleFont    = null;
-        promptFont   = null;
-        buttonFont   = null;
-        inputQuery   = null;
-        cursorSource = null;
+        titleFont  = null;
+        promptFont = null;
+        buttonFont = null;
     }
 
     /**
@@ -123,6 +110,11 @@ public class GameOverScene extends Scene {
             return;
         }
 
+        IInputQuery inputQuery = context.get(IInputQuery.class);
+        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
+        ICursorSource cursorSource = inputRegistry.hasExtension(ICursorSource.class)
+            ? inputRegistry.getExtension(ICursorSource.class) : null;
+        // cursorSource stays null if not registered; guard below handles it cleanly
         if (cursorSource != null) {
             retryButton.updateInput(cursorSource, inputQuery);
             mainMenuButton.updateInput(cursorSource, inputQuery);

--- a/core/src/main/java/com/p1_7/game/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameScene.java
@@ -76,20 +76,8 @@ public class GameScene extends Scene {
     /** the player entity — created at scene entry, released on exit */
     private Player player;
 
-    /** input query for reading action states each frame */
-    private IInputQuery inputQuery;
-
-    /** collision manager sourced from the engine service context */
-    private MazeCollisionManager collisionManager;
-
-    /** movement manager sourced from the engine service context */
-    private GameMovementManager movementManager;
-
     /** wall collidables registered with the collision manager for this scene */
     private List<WallCollidable> wallCollidables;
-
-    /** level orchestrator sourced from the engine service context */
-    private ILevelOrchestrator orchestrator;
 
     /** tracks whether the player is currently overlapping each answer room */
     private boolean[] playerInsideRoom;
@@ -158,14 +146,13 @@ public class GameScene extends Scene {
         this.layout   = MazeLayout.createDefault();
         float[] spawn = layout.getSpawnPoint();
         this.player   = new Player(spawn[0], spawn[1]);
-        this.inputQuery = context.get(IInputQuery.class);
 
         // wire movement manager and register the player for position integration
-        this.movementManager = context.get(GameMovementManager.class);
+        GameMovementManager movementManager = context.get(GameMovementManager.class);
         movementManager.registerMovable(player);
 
         // wire collision manager and register the player and all walls
-        this.collisionManager = context.get(MazeCollisionManager.class);
+        MazeCollisionManager collisionManager = context.get(MazeCollisionManager.class);
         this.wallCollidables  = new ArrayList<>();
         collisionManager.registerPlayer(player);
         for (float[] rect : layout.getWallBounds()) {
@@ -175,7 +162,7 @@ public class GameScene extends Scene {
         }
 
         // wire level orchestrator and start the session at easy difficulty
-        this.orchestrator = context.get(ILevelOrchestrator.class);
+        ILevelOrchestrator orchestrator = context.get(ILevelOrchestrator.class);
         orchestrator.startLevel(Difficulty.EASY);
 
         // initialise per-room entry state and cooldown timers
@@ -241,7 +228,7 @@ public class GameScene extends Scene {
         }
 
         // populate the room answer cache for the initial question
-        refreshRoomAnswerCache();
+        refreshRoomAnswerCache(orchestrator);
 
         // question panel — begins its slide animation immediately (scene starts at QUESTION_INTRO)
         this.questionPanel = new QuestionPanel(promptFont);
@@ -330,6 +317,9 @@ public class GameScene extends Scene {
      */
     @Override
     public void onExit(SceneContext context) {
+        GameMovementManager movementManager = context.get(GameMovementManager.class);
+        MazeCollisionManager collisionManager = context.get(MazeCollisionManager.class);
+
         // unregister the player from movement before clearing references
         movementManager.unregisterMovable(player);
 
@@ -339,7 +329,6 @@ public class GameScene extends Scene {
             collisionManager.unregisterWall(wall);
         }
 
-        orchestrator       = null;
         playerInsideRoom   = null;
         roomCooldownTimers = null;
         cachedRoomBounds   = null;
@@ -356,12 +345,9 @@ public class GameScene extends Scene {
         if (brightnessOverlay != null) brightnessOverlay.dispose();
         brightnessOverlay  = null;
 
-        layout           = null;
-        player           = null;
-        inputQuery       = null;
-        movementManager  = null;
-        collisionManager = null;
-        wallCollidables  = null;
+        layout          = null;
+        player          = null;
+        wallCollidables = null;
     }
 
     /**
@@ -377,11 +363,13 @@ public class GameScene extends Scene {
      */
     @Override
     public void update(float deltaTime, SceneContext context) {
+        ILevelOrchestrator orchestrator = context.get(ILevelOrchestrator.class);
+        IInputQuery inputQuery = context.get(IInputQuery.class);
         RoundPhase phase = orchestrator.getPhase();
 
         // detect phase change and react (reset player on ROUND_RESET, start hold timer)
         if (phase != lastKnownPhase) {
-            onPhaseChanged(lastKnownPhase, phase);
+            onPhaseChanged(lastKnownPhase, phase, orchestrator);
             lastKnownPhase = phase;
         }
 
@@ -404,7 +392,7 @@ public class GameScene extends Scene {
                     // reactions like player.resetToSpawn() are not delayed by one tick
                     RoundPhase newPhase = orchestrator.getPhase();
                     if (newPhase != lastKnownPhase) {
-                        onPhaseChanged(lastKnownPhase, newPhase);
+                        onPhaseChanged(lastKnownPhase, newPhase, orchestrator);
                         lastKnownPhase = newPhase;
                     }
                 }
@@ -414,7 +402,7 @@ public class GameScene extends Scene {
 
         // choosing phase: resolve player input then check room entry
         player.update(deltaTime, inputQuery, phase);
-        checkRoomEntry(deltaTime);
+        checkRoomEntry(deltaTime, orchestrator);
     }
 
     /**
@@ -447,10 +435,11 @@ public class GameScene extends Scene {
      * called whenever the round phase changes. resets the player to spawn on ROUND_RESET
      * and starts the hold timer for non-interactive phases.
      *
-     * @param from the previous phase (null on first frame)
-     * @param to   the new phase
+     * @param from         the previous phase (null on first frame)
+     * @param to           the new phase
+     * @param orchestrator the level orchestrator for reading questions and room assignments
      */
-    private void onPhaseChanged(RoundPhase from, RoundPhase to) {
+    private void onPhaseChanged(RoundPhase from, RoundPhase to, ILevelOrchestrator orchestrator) {
         if (to == RoundPhase.ROUND_RESET) {
             // new question loading — return player to spawn and clear room state
             player.resetToSpawn(layout.getSpawnPoint());
@@ -459,7 +448,7 @@ public class GameScene extends Scene {
         }
         if (to == RoundPhase.QUESTION_INTRO) {
             // update the room answer cache for the new question, then slide the panel
-            refreshRoomAnswerCache();
+            refreshRoomAnswerCache(orchestrator);
             questionPanel.beginIntro(orchestrator.getCurrentQuestion().getPrompt());
         }
         if (to != RoundPhase.CHOOSING) {
@@ -478,9 +467,10 @@ public class GameScene extends Scene {
      * until the player physically exits; this means re-entry cannot fire again without
      * the player leaving first, which is the correct guard for the cooldown path.
      *
-     * @param deltaTime seconds elapsed since the previous frame, used to tick cooldowns
+     * @param deltaTime    seconds elapsed since the previous frame, used to tick cooldowns
+     * @param orchestrator the level orchestrator used to submit the player's room choice
      */
-    private void checkRoomEntry(float deltaTime) {
+    private void checkRoomEntry(float deltaTime, ILevelOrchestrator orchestrator) {
         IBounds playerBounds = player.getBounds();
 
         for (int i = 0; i < playerInsideRoom.length; i++) {
@@ -541,8 +531,10 @@ public class GameScene extends Scene {
      *
      * called once in onEnter and once each time QUESTION_INTRO begins so that
      * room renderables never allocate during their hot render path.
+     *
+     * @param orchestrator the level orchestrator used to read the current room assignment
      */
-    private void refreshRoomAnswerCache() {
+    private void refreshRoomAnswerCache(ILevelOrchestrator orchestrator) {
         for (int i = 0; i < 4; i++) {
             roomAnswerTexts[i] = String.valueOf(orchestrator.getRoomAssignment().getAnswerForRoom(i));
             // setText() updates the layout in-place — no new GlyphLayout allocation

--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -25,10 +25,6 @@ public class LevelCompleteScene extends Scene {
     private static final String BTN_ASSET = "menu/button.png";
     private static final String HOVER_ASSET = "menu/button_hover.png";
 
-    // ── input ────────────────────────────────────────────────────
-    private ICursorSource cursorSource;
-    private IInputQuery inputQuery;
-
     private BitmapFont titleFont;
     private BitmapFont promptFont;
     private BitmapFont buttonFont;
@@ -54,13 +50,6 @@ public class LevelCompleteScene extends Scene {
         promptFont = fontManager.getPromptFont();
         buttonFont = fontManager.getDarkTextFont(22);
 
-        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        inputQuery = context.get(IInputQuery.class);
-        if (inputRegistry.hasExtension(ICursorSource.class)) {
-            cursorSource = inputRegistry.getExtension(ICursorSource.class);
-        }
-        // cursorSource stays null if not registered; update() guard handles it cleanly
-
         float cx = Settings.getWindowWidth() / 2f;
         float cy = Settings.getWindowHeight() / 2f;
         boolean lastLevel = isLastLevel();
@@ -84,11 +73,9 @@ public class LevelCompleteScene extends Scene {
         if (continueButton != null) continueButton.dispose();
         if (mainMenuButton != null) mainMenuButton.dispose();
         if (brightnessOverlay != null) brightnessOverlay.dispose();
-        titleFont = null;
+        titleFont  = null;
         promptFont = null;
         buttonFont = null;
-        inputQuery = null;
-        cursorSource = null;
     }
 
     @Override
@@ -98,6 +85,11 @@ public class LevelCompleteScene extends Scene {
             return;
         }
 
+        IInputQuery inputQuery = context.get(IInputQuery.class);
+        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
+        ICursorSource cursorSource = inputRegistry.hasExtension(ICursorSource.class)
+            ? inputRegistry.getExtension(ICursorSource.class) : null;
+        // cursorSource stays null if not registered; guard below handles it cleanly
         if (cursorSource != null) {
             continueButton.updateInput(cursorSource, inputQuery);
             mainMenuButton.updateInput(cursorSource, inputQuery);

--- a/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/MenuScene.java
@@ -47,10 +47,6 @@ public class MenuScene extends Scene {
     private BitmapFont titleFont;
     private BitmapFont buttonFont;
 
-    // ── input ────────────────────────────────────────────────────
-    private ICursorSource cursorSource;
-    private IInputQuery inputQuery;
-
     // ── ui components ────────────────────────────────────────────
     private BackgroundImage background;
     private Text           titleText;
@@ -68,13 +64,6 @@ public class MenuScene extends Scene {
         // compute layout from the current resolution so changes via setResolution take effect
         centreX       = Settings.getWindowWidth()  / 2f;
         firstButtonY  = Settings.getWindowHeight() * 0.45f;
-
-        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        inputQuery = context.get(IInputQuery.class);
-        if (inputRegistry.hasExtension(ICursorSource.class)) {
-            cursorSource = inputRegistry.getExtension(ICursorSource.class);
-        }
-        // cursorSource stays null if not registered; update() guard handles it cleanly
 
         IAudioManager audio = context.get(IAudioManager.class);
         IFontManager fontManager = context.get(IFontManager.class);
@@ -107,17 +96,19 @@ public class MenuScene extends Scene {
         if (brightnessOverlay != null) brightnessOverlay.dispose();
         titleFont = null;
         buttonFont = null;
-        inputQuery = null;
-        cursorSource = null;
     }
 
     @Override
     public void update(float deltaTime, SceneContext context) {
+        IInputQuery inputQuery = context.get(IInputQuery.class);
         if (inputQuery.getActionState(GameActions.MENU_BACK) == InputState.PRESSED) {
             Gdx.app.exit();
             return;
         }
 
+        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
+        ICursorSource cursorSource = inputRegistry.hasExtension(ICursorSource.class)
+            ? inputRegistry.getExtension(ICursorSource.class) : null;
         if (cursorSource == null) return;
         startButton.updateInput(cursorSource, inputQuery);
         settingsButton.updateInput(cursorSource, inputQuery);

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -46,11 +46,10 @@ public class SettingScene extends Scene {
     private BitmapFont tableFont;
     private BitmapFont buttonFont;
 
-    private ICursorSource cursorSource;
-    private IInputQuery inputQuery;
+    // inputManager kept as a field — it is accessed from the remapInputProcessor callback,
+    // which fires outside the hook lifecycle and cannot receive context as a parameter
     private IInputManager inputManager;
     private InputProcessor previousInputProcessor;
-    private IFontManager fontManager;
     private final InputProcessor remapInputProcessor = new InputAdapter() {
         @Override
         public boolean keyDown(int keycode) {
@@ -65,8 +64,6 @@ public class SettingScene extends Scene {
             return true;
         }
     };
-
-    private IAudioManager audio;
 
     private BackgroundImage background;
     private Text heading;
@@ -93,8 +90,10 @@ public class SettingScene extends Scene {
     public void onEnter(SceneContext context) {
         computeSceneCenter();
         resolveSceneServices(context);
-        createFonts();
-        createSceneComponents();
+        IFontManager fontManager = context.get(IFontManager.class);
+        IAudioManager audio = context.get(IAudioManager.class);
+        createFonts(fontManager);
+        createSceneComponents(audio);
         syncRemapBindings();
     }
 
@@ -117,14 +116,19 @@ public class SettingScene extends Scene {
             return;
         }
 
+        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
+        ICursorSource cursorSource = inputRegistry.hasExtension(ICursorSource.class)
+            ? inputRegistry.getExtension(ICursorSource.class) : null;
         if (cursorSource == null) {
             return;
         }
 
-        updateSliderInputs();
-        updateRemapInput();
-        updateBackButtonInput();
-        applySliderChanges();
+        IInputQuery inputQuery = context.get(IInputQuery.class);
+        IAudioManager audio = context.get(IAudioManager.class);
+        updateSliderInputs(cursorSource, inputQuery);
+        updateRemapInput(cursorSource, inputQuery);
+        updateBackButtonInput(cursorSource, inputQuery);
+        applySliderChanges(audio);
         handleBackButtonClick(context);
     }
 
@@ -142,25 +146,19 @@ public class SettingScene extends Scene {
     }
 
     private void resolveSceneServices(SceneContext context) {
-        IInputExtensionRegistry inputRegistry = context.get(IInputExtensionRegistry.class);
-        if (inputRegistry.hasExtension(ICursorSource.class)) {
-            cursorSource = inputRegistry.getExtension(ICursorSource.class);
-        }
-
+        // inputManager is kept as a field — needed by syncRemapBindings(), which is called
+        // from the remapInputProcessor callback outside the normal hook lifecycle
         inputManager = context.get(IInputManager.class);
-        inputQuery = context.get(IInputQuery.class);
-        audio = context.get(IAudioManager.class);
-        fontManager = context.get(IFontManager.class);
     }
 
-    private void createFonts() {
+    private void createFonts(IFontManager fontManager) {
         headingFont = fontManager.getGoldDisplayFont(52);
         labelFont = fontManager.getDarkTextFont(28);
         tableFont = fontManager.getDarkTextFont(22);
         buttonFont = fontManager.getDarkTextFont(26);
     }
 
-    private void createSceneComponents() {
+    private void createSceneComponents(IAudioManager audio) {
         float screenHeight = Settings.getWindowHeight();
         float backButtonY = screenHeight * 0.085f;
         float hintY = backButtonY + 54f;
@@ -176,7 +174,7 @@ public class SettingScene extends Scene {
 
         background = new BackgroundImage(BG_ASSET);
         heading = createCenteredLabel("SETTINGS", headingY, headingFont);
-        volumeLabel = createCenteredLabel(volumeText(), volumeLabelY, labelFont);
+        volumeLabel = createCenteredLabel(volumeText(audio), volumeLabelY, labelFont);
         brightnessLabel = createCenteredLabel(brightnessText(), brightnessLabelY, labelFont);
         controlsHeading = createCenteredLabel("CONTROLS", controlsHeadingY, buttonFont);
         remapHint = createCenteredLabel(idleRemapHintText(), hintY, tableFont);
@@ -252,15 +250,12 @@ public class SettingScene extends Scene {
     }
 
     private void clearResolvedServices() {
-        audio = null;
-        cursorSource = null;
-        inputQuery = null;
         inputManager = null;
-        fontManager = null;
         previousInputProcessor = null;
     }
 
     private boolean handleSceneExit(SceneContext context) {
+        IInputQuery inputQuery = context.get(IInputQuery.class);
         if (inputQuery.getActionState(GameActions.MENU_BACK) == InputState.PRESSED) {
             context.changeScene("menu");
             return true;
@@ -268,19 +263,19 @@ public class SettingScene extends Scene {
         return false;
     }
 
-    private void updateSliderInputs() {
+    private void updateSliderInputs(ICursorSource cursorSource, IInputQuery inputQuery) {
         volumeSlider.updateInput(cursorSource, inputQuery);
         brightnessSlider.updateInput(cursorSource, inputQuery);
     }
 
-    private void updateBackButtonInput() {
+    private void updateBackButtonInput(ICursorSource cursorSource, IInputQuery inputQuery) {
         backButton.updateInput(cursorSource, inputQuery);
     }
 
-    private void applySliderChanges() {
+    private void applySliderChanges(IAudioManager audio) {
         if (volumeSlider.hasMoved()) {
             audio.setMusicVolume(volumeSlider.getValue());
-            volumeLabel.setText(volumeText());
+            volumeLabel.setText(volumeText(audio));
             volumeSlider.resetMoved();
         }
         if (brightnessSlider.hasMoved()) {
@@ -316,7 +311,7 @@ public class SettingScene extends Scene {
         renderQueue.queue(remapHint);
     }
 
-    private String volumeText() {
+    private String volumeText(IAudioManager audio) {
         return "Music Volume:  " + Math.round(audio.getMusicVolume() * 100) + "%";
     }
 
@@ -376,7 +371,7 @@ public class SettingScene extends Scene {
         return fallbackKeyCode;
     }
 
-    private void updateRemapInput() {
+    private void updateRemapInput(ICursorSource cursorSource, IInputQuery inputQuery) {
         float mx = cursorSource.getCursorX();
         float my = cursorSource.getCursorY();
         boolean clickStarted =


### PR DESCRIPTION
## Summary

- Removes service fields (`IInputQuery`, `ILevelOrchestrator`, `GameMovementManager`, `MazeCollisionManager`, `IAudioManager`, `IFontManager`, `IInputExtensionRegistry`) cached in `onEnter` across all five scene classes
- Each hook (`onEnter`, `onExit`, `update`) now resolves the services it needs directly from its own `context` parameter
- `IInputManager` is retained as a field in `SettingScene` only — it is required by the `remapInputProcessor` callback, which fires outside the hook lifecycle and has no access to `context`

## Test plan

- [x] Build compiles cleanly (`./gradlew compileJava`)
- [x] Menu scene: start/settings/exit buttons navigate correctly; background music plays
- [x] Settings scene: volume slider, brightness slider, and key remapping all function correctly; ESC returns to menu
- [x] Game scene: player moves and collides with walls; answering rooms advances or resets the round; score and health update correctly
- [x] Game over scene: SPACE retries, ESC returns to main menu
- [x] Level complete scene: SPACE continues, ESC returns to main menu

Closes #72