### PR TITLE
fix: consolidate inputManager comment and complete LevelCompleteScene onExit cleanup

### DIFF
--- a/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/LevelCompleteScene.java
@@ -73,9 +73,17 @@ public class LevelCompleteScene extends Scene {
         if (continueButton != null) continueButton.dispose();
         if (mainMenuButton != null) mainMenuButton.dispose();
         if (brightnessOverlay != null) brightnessOverlay.dispose();
-        titleFont  = null;
-        promptFont = null;
-        buttonFont = null;
+        background        = null;
+        title             = null;
+        promptStatus      = null;
+        hintSpace         = null;
+        hintEsc           = null;
+        continueButton    = null;
+        mainMenuButton    = null;
+        brightnessOverlay = null;
+        titleFont         = null;
+        promptFont        = null;
+        buttonFont        = null;
     }
 
     @Override

--- a/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/SettingScene.java
@@ -46,8 +46,9 @@ public class SettingScene extends Scene {
     private BitmapFont tableFont;
     private BitmapFont buttonFont;
 
-    // inputManager kept as a field — it is accessed from the remapInputProcessor callback,
-    // which fires outside the hook lifecycle and cannot receive context as a parameter
+    // kept as a field because syncRemapBindings() is called via the remapInputProcessor
+    // callback chain (keyDown → applyActiveRemap → syncRemapBindings), which fires outside
+    // the hook lifecycle and cannot receive context as a parameter
     private IInputManager inputManager;
     private InputProcessor previousInputProcessor;
     private final InputProcessor remapInputProcessor = new InputAdapter() {
@@ -146,8 +147,7 @@ public class SettingScene extends Scene {
     }
 
     private void resolveSceneServices(SceneContext context) {
-        // inputManager is kept as a field — needed by syncRemapBindings(), which is called
-        // from the remapInputProcessor callback outside the normal hook lifecycle
+        // see field declaration for why inputManager is retained across hooks
         inputManager = context.get(IInputManager.class);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #133, addressing two issues found during code review:

- **`SettingScene`**: consolidate the duplicated `inputManager` field justification into a single comment on the field declaration; the comment in `resolveSceneServices()` is replaced with a cross-reference. The new comment explicitly names the callback chain (`keyDown → applyActiveRemap → syncRemapBindings`) so it is clear why the field cannot be eliminated.
- **`LevelCompleteScene`**: `onExit()` was missing null-outs for `background`, `title`, `promptStatus`, `hintSpace`, `hintEsc`, `continueButton`, `mainMenuButton`, and `brightnessOverlay`, leaving live references on a departing scene. Brought in line with `GameOverScene.onExit()`.

## Test plan

- [x] Build compiles cleanly (`./gradlew compileJava`)
- [x] Settings scene remap flow works end-to-end (key remap, cancel, apply)
- [x] Level complete scene transitions correctly to game and main menu

Closes #72