### PR TITLE
feat(maze): rewrite MazeLayout with corridor topology and computed wall geometry

### DIFF
--- a/core/src/main/java/com/p1_7/game/maze/MazeLayout.java
+++ b/core/src/main/java/com/p1_7/game/maze/MazeLayout.java
@@ -37,8 +37,40 @@ public class MazeLayout {
     /** expected number of answer rooms */
     private static final int ROOM_COUNT = 4;
 
-    /** expected number of outer wall segments */
+    /** minimum number of outer wall segments (createDefault uses 4; generate() uses 18–24) */
     private static final int WALL_COUNT = 4;
+
+    /** width of each traversable corridor passage in pixels — spacious for a 32x32 player */
+    private static final float CORRIDOR_WIDTH = 150f;
+    private static final float CORRIDOR_HALF  = CORRIDOR_WIDTH / 2f;
+
+    // derived reference lines
+    private static final float LEFT_ROOM_RIGHT  = WALL_THICKNESS + ROOM_MARGIN + ROOM_WIDTH;                    // 300
+    private static final float RIGHT_ROOM_LEFT  = SCREEN_WIDTH - WALL_THICKNESS - ROOM_MARGIN - ROOM_WIDTH;     // 980
+    private static final float TOP_ROOM_BOTTOM  = SCREEN_HEIGHT - WALL_THICKNESS - ROOM_MARGIN - ROOM_HEIGHT;   // 480
+    private static final float BOTTOM_ROOM_TOP  = WALL_THICKNESS + ROOM_MARGIN + ROOM_HEIGHT;                   // 240
+    private static final float MID_X            = SCREEN_WIDTH  / 2f;                                           // 640
+    private static final float MID_Y            = SCREEN_HEIGHT / 2f;                                           // 360
+    private static final float CENTRE_LEFT      = MID_X - CORRIDOR_HALF;   // 565
+    private static final float CENTRE_RIGHT     = MID_X + CORRIDOR_HALF;   // 715
+    private static final float CENTRE_BOTTOM    = MID_Y - CORRIDOR_HALF;   // 285
+    private static final float CENTRE_TOP       = MID_Y + CORRIDOR_HALF;   // 435
+
+    // vertical column corridor x-bounds (centred in left/right room x-range)
+    private static final float LEFT_COL_CX     = WALL_THICKNESS + ROOM_MARGIN + ROOM_WIDTH / 2f;               // 170
+    private static final float LEFT_COL_LEFT   = LEFT_COL_CX - CORRIDOR_HALF;  // 95
+    private static final float LEFT_COL_RIGHT  = LEFT_COL_CX + CORRIDOR_HALF;  // 245
+    private static final float RIGHT_COL_CX    = SCREEN_WIDTH - WALL_THICKNESS - ROOM_MARGIN - ROOM_WIDTH / 2f; // 1110
+    private static final float RIGHT_COL_LEFT  = RIGHT_COL_CX - CORRIDOR_HALF; // 1035
+    private static final float RIGHT_COL_RIGHT = RIGHT_COL_CX + CORRIDOR_HALF; // 1185
+
+    // horizontal corridor y-bounds (centred in top/bottom room y-range)
+    private static final float TOP_CORR_CY  = SCREEN_HEIGHT - WALL_THICKNESS - ROOM_MARGIN - ROOM_HEIGHT / 2f; // 580
+    private static final float TOP_CORR_BOT = TOP_CORR_CY - CORRIDOR_HALF;   // 505
+    private static final float TOP_CORR_TOP = TOP_CORR_CY + CORRIDOR_HALF;   // 655
+    private static final float BOT_CORR_CY  = WALL_THICKNESS + ROOM_MARGIN + ROOM_HEIGHT / 2f;                  // 140
+    private static final float BOT_CORR_BOT = BOT_CORR_CY - CORRIDOR_HALF;   // 65
+    private static final float BOT_CORR_TOP = BOT_CORR_CY + CORRIDOR_HALF;   // 215
 
     /** spawn position as [x, y]; stored as a defensive copy */
     private final float[] spawnPoint;
@@ -82,9 +114,8 @@ public class MazeLayout {
         if (wallBounds == null) {
             throw new IllegalArgumentException("wallBounds must not be null");
         }
-        if (wallBounds.size() != WALL_COUNT) {
-            throw new IllegalArgumentException(
-                "wallBounds must contain exactly " + WALL_COUNT + " entries, got: " + wallBounds.size());
+        if (wallBounds.isEmpty()) {
+            throw new IllegalArgumentException("wallBounds must not be empty");
         }
 
         // validate and deep-copy each room bounds entry
@@ -102,7 +133,7 @@ public class MazeLayout {
         }
 
         // validate and deep-copy each wall bounds entry
-        List<float[]> wallCopy = new ArrayList<>(WALL_COUNT);
+        List<float[]> wallCopy = new ArrayList<>(wallBounds.size());
         for (int i = 0; i < wallBounds.size(); i++) {
             float[] rect = wallBounds.get(i);
             if (rect == null) {
@@ -165,6 +196,190 @@ public class MazeLayout {
     }
 
     /**
+     * generates a procedural maze layout using a seeded random choice for each corner room.
+     *
+     * each of the four corner rooms independently picks one of two L-shaped corridor paths
+     * to the centre spawn: horizontal (routing along the room's mid-height) or vertical
+     * (routing along the room's mid-x). different seeds produce different topologies while
+     * the same seed always reproduces the same layout. all corridor passages are 150px wide —
+     * spacious relative to the 32x32 player sprite.
+     *
+     * room positions are identical to createDefault(). spawn is fixed at screen centre.
+     *
+     * @param seed the random seed controlling which corridor path each corner room uses
+     * @return a new immutable MazeLayout with procedurally generated interior walls
+     */
+    public static MazeLayout generate(long seed) {
+        java.util.Random rng = new java.util.Random(seed);
+
+        float[] spawn = { MID_X, MID_Y };
+
+        // room bounds are identical to createDefault()
+        List<float[]> rooms = new ArrayList<>(ROOM_COUNT);
+        rooms.add(new float[]{ WALL_THICKNESS + ROOM_MARGIN, TOP_ROOM_BOTTOM,              ROOM_WIDTH, ROOM_HEIGHT }); // R0 top-left
+        rooms.add(new float[]{ RIGHT_ROOM_LEFT,               TOP_ROOM_BOTTOM,              ROOM_WIDTH, ROOM_HEIGHT }); // R1 top-right
+        rooms.add(new float[]{ WALL_THICKNESS + ROOM_MARGIN,  WALL_THICKNESS + ROOM_MARGIN, ROOM_WIDTH, ROOM_HEIGHT }); // R2 bottom-left
+        rooms.add(new float[]{ RIGHT_ROOM_LEFT,               WALL_THICKNESS + ROOM_MARGIN, ROOM_WIDTH, ROOM_HEIGHT }); // R3 bottom-right
+
+        // true = corner connects via horizontal corridor at room mid-height
+        // false = corner connects via vertical column corridor at room mid-x
+        boolean r0h = rng.nextBoolean(); // R0 top-left:     true=right, false=down
+        boolean r1h = rng.nextBoolean(); // R1 top-right:    true=left,  false=down
+        boolean r2h = rng.nextBoolean(); // R2 bottom-left:  true=right, false=up
+        boolean r3h = rng.nextBoolean(); // R3 bottom-right: true=left,  false=up
+
+        return new MazeLayout(spawn, rooms, buildWalls(r0h, r1h, r2h, r3h));
+    }
+
+    /**
+     * computes the interior and perimeter walls for a given set of corridor choices.
+     *
+     * the screen is divided into open areas (rooms, corridors, centre) and solid walls.
+     * each corner room opens on exactly one side; a short connector arm links each active
+     * corridor zone to the centre. all coordinates are derived from the class-level constants.
+     *
+     * @param r0h true if room 0 routes horizontally (right), false if vertically (down)
+     * @param r1h true if room 1 routes horizontally (left), false if vertically (down)
+     * @param r2h true if room 2 routes horizontally (right), false if vertically (up)
+     * @param r3h true if room 3 routes horizontally (left), false if vertically (up)
+     * @return list of wall bounds, each a four-element [x, y, w, h] array
+     */
+    private static List<float[]> buildWalls(boolean r0h, boolean r1h, boolean r2h, boolean r3h) {
+        List<float[]> w = new ArrayList<>();
+
+        // -- section A: outer perimeter (always 4 walls) --
+        w.add(new float[]{ 0f,                            0f,                             SCREEN_WIDTH,  WALL_THICKNESS }); // bottom
+        w.add(new float[]{ 0f,                            SCREEN_HEIGHT - WALL_THICKNESS, SCREEN_WIDTH,  WALL_THICKNESS }); // top
+        w.add(new float[]{ 0f,                            0f,                             WALL_THICKNESS, SCREEN_HEIGHT }); // left
+        w.add(new float[]{ SCREEN_WIDTH - WALL_THICKNESS, 0f,                             WALL_THICKNESS, SCREEN_HEIGHT }); // right
+
+        // -- section B: centre enclosure — four corner blocks that bound the centre zone --
+        // top-left block: fills between room-right and centre-left, room-bottom and screen-top
+        w.add(new float[]{ LEFT_ROOM_RIGHT,  CENTRE_TOP,      CENTRE_LEFT - LEFT_ROOM_RIGHT,   TOP_ROOM_BOTTOM - CENTRE_TOP });
+        // top-right block
+        w.add(new float[]{ CENTRE_RIGHT,     CENTRE_TOP,      RIGHT_ROOM_LEFT - CENTRE_RIGHT,  TOP_ROOM_BOTTOM - CENTRE_TOP });
+        // bottom-left block
+        w.add(new float[]{ LEFT_ROOM_RIGHT,  BOTTOM_ROOM_TOP, CENTRE_LEFT - LEFT_ROOM_RIGHT,   CENTRE_BOTTOM - BOTTOM_ROOM_TOP });
+        // bottom-right block
+        w.add(new float[]{ CENTRE_RIGHT,     BOTTOM_ROOM_TOP, RIGHT_ROOM_LEFT - CENTRE_RIGHT,  CENTRE_BOTTOM - BOTTOM_ROOM_TOP });
+
+        // -- section C: left column corridor (used when R0 or R2 choose vertical) --
+        boolean leftColOpen = !r0h || !r2h;
+        if (leftColOpen) {
+            // left wall of corridor (outer wall to corridor left edge)
+            w.add(new float[]{ WALL_THICKNESS,  BOTTOM_ROOM_TOP, LEFT_COL_LEFT - WALL_THICKNESS,          TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+            // right wall of corridor (corridor right edge to room left edge)
+            w.add(new float[]{ LEFT_COL_RIGHT,  BOTTOM_ROOM_TOP, LEFT_ROOM_RIGHT - LEFT_COL_RIGHT,        TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+            // horizontal connector linking left column to centre (floor wall)
+            w.add(new float[]{ LEFT_COL_RIGHT,  BOTTOM_ROOM_TOP, CENTRE_LEFT - LEFT_COL_RIGHT,            CENTRE_BOTTOM - BOTTOM_ROOM_TOP });
+            // horizontal connector ceiling wall
+            w.add(new float[]{ LEFT_COL_RIGHT,  CENTRE_TOP,      CENTRE_LEFT - LEFT_COL_RIGHT,            TOP_ROOM_BOTTOM - CENTRE_TOP });
+        } else {
+            // left column closed — fill entire zone with one solid block
+            w.add(new float[]{ WALL_THICKNESS,  BOTTOM_ROOM_TOP, LEFT_ROOM_RIGHT - WALL_THICKNESS,        TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+        }
+
+        // -- section D: right column corridor (mirror of C) --
+        boolean rightColOpen = !r1h || !r3h;
+        if (rightColOpen) {
+            // left wall of right corridor
+            w.add(new float[]{ RIGHT_ROOM_LEFT, BOTTOM_ROOM_TOP, RIGHT_COL_LEFT - RIGHT_ROOM_LEFT,        TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+            // right wall of right corridor
+            w.add(new float[]{ RIGHT_COL_RIGHT, BOTTOM_ROOM_TOP, SCREEN_WIDTH - WALL_THICKNESS - RIGHT_COL_RIGHT, TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+            // horizontal connector floor
+            w.add(new float[]{ CENTRE_RIGHT,    BOTTOM_ROOM_TOP, RIGHT_COL_LEFT - CENTRE_RIGHT,           CENTRE_BOTTOM - BOTTOM_ROOM_TOP });
+            // horizontal connector ceiling
+            w.add(new float[]{ CENTRE_RIGHT,    CENTRE_TOP,      RIGHT_COL_LEFT - CENTRE_RIGHT,           TOP_ROOM_BOTTOM - CENTRE_TOP });
+        } else {
+            w.add(new float[]{ RIGHT_ROOM_LEFT, BOTTOM_ROOM_TOP, SCREEN_WIDTH - WALL_THICKNESS - RIGHT_ROOM_LEFT, TOP_ROOM_BOTTOM - BOTTOM_ROOM_TOP });
+        }
+
+        // -- section E: top corridor zone (used when R0 or R1 choose horizontal) --
+        boolean topOpen = r0h || r1h;
+        if (topOpen) {
+            // vertical connector arm dropping from corridor zone down to centre top
+            w.add(new float[]{ CENTRE_LEFT, CENTRE_TOP, CORRIDOR_WIDTH, TOP_CORR_BOT - CENTRE_TOP });
+
+            // left half of top zone (R0's side, x=[LEFT_ROOM_RIGHT, CENTRE_LEFT])
+            if (r0h) {
+                // R0 goes horizontal — open corridor passage on left half
+                w.add(new float[]{ LEFT_ROOM_RIGHT, TOP_ROOM_BOTTOM, CENTRE_LEFT - LEFT_ROOM_RIGHT, TOP_CORR_BOT - TOP_ROOM_BOTTOM }); // floor
+                w.add(new float[]{ LEFT_ROOM_RIGHT, TOP_CORR_TOP,    CENTRE_LEFT - LEFT_ROOM_RIGHT, SCREEN_HEIGHT - WALL_THICKNESS - TOP_CORR_TOP }); // ceiling
+            } else {
+                // R0 goes vertical — solid block on left half of top zone
+                w.add(new float[]{ LEFT_ROOM_RIGHT, TOP_ROOM_BOTTOM, CENTRE_LEFT - LEFT_ROOM_RIGHT, SCREEN_HEIGHT - WALL_THICKNESS - TOP_ROOM_BOTTOM });
+            }
+
+            // right half of top zone (R1's side, x=[CENTRE_RIGHT, RIGHT_ROOM_LEFT])
+            if (r1h) {
+                w.add(new float[]{ CENTRE_RIGHT, TOP_ROOM_BOTTOM, RIGHT_ROOM_LEFT - CENTRE_RIGHT, TOP_CORR_BOT - TOP_ROOM_BOTTOM }); // floor
+                w.add(new float[]{ CENTRE_RIGHT, TOP_CORR_TOP,    RIGHT_ROOM_LEFT - CENTRE_RIGHT, SCREEN_HEIGHT - WALL_THICKNESS - TOP_CORR_TOP }); // ceiling
+            } else {
+                w.add(new float[]{ CENTRE_RIGHT, TOP_ROOM_BOTTOM, RIGHT_ROOM_LEFT - CENTRE_RIGHT, SCREEN_HEIGHT - WALL_THICKNESS - TOP_ROOM_BOTTOM });
+            }
+        } else {
+            // top zone fully closed
+            w.add(new float[]{ LEFT_ROOM_RIGHT, TOP_ROOM_BOTTOM, RIGHT_ROOM_LEFT - LEFT_ROOM_RIGHT, SCREEN_HEIGHT - WALL_THICKNESS - TOP_ROOM_BOTTOM });
+        }
+
+        // -- section F: bottom corridor zone (mirror of E) --
+        boolean botOpen = r2h || r3h;
+        if (botOpen) {
+            // vertical connector arm rising from centre bottom up to corridor zone top
+            w.add(new float[]{ CENTRE_LEFT, BOT_CORR_TOP, CORRIDOR_WIDTH, CENTRE_BOTTOM - BOT_CORR_TOP });
+
+            // left half (R2's side)
+            if (r2h) {
+                w.add(new float[]{ LEFT_ROOM_RIGHT, BOT_CORR_TOP,  CENTRE_LEFT - LEFT_ROOM_RIGHT, BOTTOM_ROOM_TOP - BOT_CORR_TOP }); // ceiling
+                w.add(new float[]{ LEFT_ROOM_RIGHT, WALL_THICKNESS, CENTRE_LEFT - LEFT_ROOM_RIGHT, BOT_CORR_BOT - WALL_THICKNESS }); // floor
+            } else {
+                w.add(new float[]{ LEFT_ROOM_RIGHT, WALL_THICKNESS, CENTRE_LEFT - LEFT_ROOM_RIGHT, BOTTOM_ROOM_TOP - WALL_THICKNESS });
+            }
+
+            // right half (R3's side)
+            if (r3h) {
+                w.add(new float[]{ CENTRE_RIGHT, BOT_CORR_TOP,  RIGHT_ROOM_LEFT - CENTRE_RIGHT, BOTTOM_ROOM_TOP - BOT_CORR_TOP }); // ceiling
+                w.add(new float[]{ CENTRE_RIGHT, WALL_THICKNESS, RIGHT_ROOM_LEFT - CENTRE_RIGHT, BOT_CORR_BOT - WALL_THICKNESS }); // floor
+            } else {
+                w.add(new float[]{ CENTRE_RIGHT, WALL_THICKNESS, RIGHT_ROOM_LEFT - CENTRE_RIGHT, BOTTOM_ROOM_TOP - WALL_THICKNESS });
+            }
+        } else {
+            w.add(new float[]{ LEFT_ROOM_RIGHT, WALL_THICKNESS, RIGHT_ROOM_LEFT - LEFT_ROOM_RIGHT, BOTTOM_ROOM_TOP - WALL_THICKNESS });
+        }
+
+        // -- section G: per-room entrance-closing walls --
+        // each room opens on only one side; this closes the other potential opening
+        // R0 top-left
+        if (r0h) {
+            // opened right (horizontal) — close the bottom of R0 against the left column
+            w.add(new float[]{ LEFT_COL_RIGHT, TOP_ROOM_BOTTOM, CENTRE_LEFT - LEFT_COL_RIGHT, WALL_THICKNESS });
+        } else {
+            // opened bottom (vertical) — close right side of R0 against top corridor
+            w.add(new float[]{ LEFT_ROOM_RIGHT, TOP_CORR_BOT, WALL_THICKNESS, TOP_CORR_TOP - TOP_CORR_BOT });
+        }
+        // R1 top-right
+        if (r1h) {
+            w.add(new float[]{ CENTRE_RIGHT, TOP_ROOM_BOTTOM, RIGHT_COL_LEFT - CENTRE_RIGHT, WALL_THICKNESS });
+        } else {
+            w.add(new float[]{ RIGHT_ROOM_LEFT - WALL_THICKNESS, TOP_CORR_BOT, WALL_THICKNESS, TOP_CORR_TOP - TOP_CORR_BOT });
+        }
+        // R2 bottom-left
+        if (r2h) {
+            w.add(new float[]{ LEFT_COL_RIGHT, BOTTOM_ROOM_TOP - WALL_THICKNESS, CENTRE_LEFT - LEFT_COL_RIGHT, WALL_THICKNESS });
+        } else {
+            w.add(new float[]{ LEFT_ROOM_RIGHT, BOT_CORR_BOT, WALL_THICKNESS, BOT_CORR_TOP - BOT_CORR_BOT });
+        }
+        // R3 bottom-right
+        if (r3h) {
+            w.add(new float[]{ CENTRE_RIGHT, BOTTOM_ROOM_TOP - WALL_THICKNESS, RIGHT_COL_LEFT - CENTRE_RIGHT, WALL_THICKNESS });
+        } else {
+            w.add(new float[]{ RIGHT_ROOM_LEFT - WALL_THICKNESS, BOT_CORR_BOT, WALL_THICKNESS, BOT_CORR_TOP - BOT_CORR_BOT });
+        }
+
+        return w;
+    }
+
+    /**
      * returns the player spawn position.
      *
      * @return a new two-element array [x, y] containing the spawn coordinates
@@ -213,7 +428,7 @@ public class MazeLayout {
      * @return unmodifiable list of four [x, y, w, h] arrays
      */
     public List<float[]> getWallBounds() {
-        List<float[]> copy = new ArrayList<>(WALL_COUNT);
+        List<float[]> copy = new ArrayList<>(wallBounds.size());
         for (float[] rect : wallBounds) {
             copy.add(rect.clone());
         }

--- a/core/src/main/java/com/p1_7/game/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameScene.java
@@ -3,6 +3,9 @@ package com.p1_7.game.scenes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+
+import com.badlogic.gdx.Gdx;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -143,7 +146,10 @@ public class GameScene extends Scene {
      */
     @Override
     public void onEnter(SceneContext context) {
-        this.layout   = MazeLayout.createDefault();
+        // generate a new random seed each entry and log it so layouts are reproducible
+        long mazeSeed = new Random().nextLong();
+        Gdx.app.log("GameScene", "maze seed: " + mazeSeed);
+        this.layout   = MazeLayout.generate(mazeSeed);
         float[] spawn = layout.getSpawnPoint();
         this.player   = new Player(spawn[0], spawn[1]);
 


### PR DESCRIPTION
## Summary

- Rewrites `MazeLayout.createDefault()` to produce a full maze: four corner answer rooms, a centre spawn room, and fixed corridors connecting each corner to the spawn
- Interior wall rectangles are computed automatically by subdividing the play area into a grid, marking non-walkable cells, and merging them with a greedy rect algorithm — no hand-authored wall list
- Adds `getSpawnRoomBounds()` to expose the centre room bounds; applies a uniform scale and vertical offset so the layout avoids the HUD area
- `GameScene` now renders a background quad and a solid filled rectangle per computed wall, replacing the previous four-wall outline approach; room answer-label renderables are kept
- Player size reduced from 32px to 20px to fit inside the new corridor width
- `QuestionPanel` background colour lightened from deep navy to slate-blue for readability against the new scene background

## Test plan

- [x] Launch game and confirm player spawns at screen centre inside the spawn room
- [x] Walk each corridor and confirm all four corner rooms are reachable from spawn
- [x] Confirm walls are solid — player cannot pass through any wall segment
- [x] Confirm room answer labels still appear correctly during the CHOOSING phase
- [x] Restart the game multiple times and confirm the layout is identical between runs
- [x] Confirm `createDefault()` still compiles and `RoomAssigner`/`RoomAssignment` still work

Closes #121