### PR TITLE
feat: expand QuestionPanel to full width and extend QUESTION_INTRO hold

### DIFF
--- a/core/src/main/java/com/p1_7/game/scenes/GameScene.java
+++ b/core/src/main/java/com/p1_7/game/scenes/GameScene.java
@@ -51,7 +51,11 @@ public class GameScene extends Scene {
     /** re-entry cooldown in seconds before a wrong room can penalise the player again */
     private static final float ROOM_COOLDOWN_SECONDS = 1.0f;
 
-    /** hold time for QUESTION_INTRO — covers 1.5 s pre-slide delay + 1.0 s slide + 2.0 s reading hold */
+    /**
+     * hold time for QUESTION_INTRO — must equal QuestionPanel.ANIM_START_DELAY (1.5 s)
+     * + QuestionPanel.ANIM_DURATION (1.0 s) + desired reading hold (2.0 s) = 4.5 s.
+     * update this constant whenever either animation constant in QuestionPanel changes.
+     */
     private static final float QUESTION_INTRO_HOLD_SECONDS = 4.5f;
 
     /** hold time in seconds for ROUND_RESET */
@@ -223,7 +227,7 @@ public class GameScene extends Scene {
         IFontManager fontManager = context.get(IFontManager.class);
         this.promptFont   = fontManager.getLightTextFont(28);
         this.questionFont = fontManager.getLightTextFont(36);
-        this.hudFont    = fontManager.getLightTextFont(22);
+        this.hudFont      = fontManager.getLightTextFont(22);
 
         // allocate per-room answer caches before the loop so closures can capture the array references
         this.roomAnswerTexts   = new String[4];
@@ -594,11 +598,13 @@ public class GameScene extends Scene {
         }
         if (to != RoundPhase.CHOOSING) {
             // terminal phases share the feedback hold so the overlay is visible before transitioning
-            phaseHoldTimer = (to == RoundPhase.FEEDBACK || isTerminalPhase(to))
-                ? FEEDBACK_HOLD_SECONDS
-                : (to == RoundPhase.QUESTION_INTRO
-                    ? QUESTION_INTRO_HOLD_SECONDS
-                    : ROUND_RESET_HOLD_SECONDS);
+            if (to == RoundPhase.FEEDBACK || isTerminalPhase(to)) {
+                phaseHoldTimer = FEEDBACK_HOLD_SECONDS;
+            } else if (to == RoundPhase.QUESTION_INTRO) {
+                phaseHoldTimer = QUESTION_INTRO_HOLD_SECONDS;
+            } else {
+                phaseHoldTimer = ROUND_RESET_HOLD_SECONDS;
+            }
         }
     }
 

--- a/core/src/main/java/com/p1_7/game/ui/QuestionPanel.java
+++ b/core/src/main/java/com/p1_7/game/ui/QuestionPanel.java
@@ -136,6 +136,9 @@ public class QuestionPanel extends Entity implements IRenderable {
     /**
      * draws the dark panel background and centres the question text within it.
      *
+     * during the pre-slide delay the panel is intentionally visible at START_Y so the
+     * player has time to read the question before it slides to the bottom of the screen.
+     *
      * @param ctx the draw context for this frame
      */
     @Override


### PR DESCRIPTION
## Summary
- `QuestionPanel` now spans the full 1280 px screen width (`PANEL_W = Settings.getWindowWidth()`, `PANEL_X = 0`)
- Added a 1.5 s pre-slide delay (`ANIM_START_DELAY`) so the question is readable before the panel moves
- Slide animation kept at 1.0 s; panel holds for a further 2.0 s at rest — total QUESTION_INTRO = 4.5 s
- Split `PHASE_HOLD_SECONDS` into `QUESTION_INTRO_HOLD_SECONDS` (4.5 s) and `ROUND_RESET_HOLD_SECONDS` (1.0 s, unchanged)
- Question panel now uses a dedicated 36 px font; room answer labels remain at 28 px
- Added `// TODO palette: replace in palette issue` on `PANEL_BG`

## Test plan
- [x] Panel background spans full 1280 px width at all times
- [x] Panel appears at rest position for ~1.5 s before sliding down
- [x] Slide completes in ~1.0 s; phase advances ~2.0 s after panel lands
- [x] Question text is visibly larger than room answer labels and centred within the panel
- [x] ROUND_RESET auto-advances in ~1 s as before
- [x] FEEDBACK hold (2 s) is unaffected
- [x] Panel rests below y = 100, clear of the HUD strip

Closes #123